### PR TITLE
Add geom/indexes and update severity buckets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -294,7 +294,7 @@ CrashMap's filter panel allows users to narrow the displayed crash data. All fil
 | **County** | Dropdown (single-select, filtered by selected state) | `Select` | `CountyName` | Cascading: only shows counties within the selected state. |
 | **City** | Dropdown (single-select, filtered by selected county) | `Select` | `CityName` | Cascading: only shows cities within the selected county. |
 | **Mode** | Toggle / segmented control | `ToggleGroup` | `Mode` | Options: Bicyclist / Pedestrian / All. Default: All. |
-| **Injury Severity** | Multi-select checkboxes | `Checkbox` + `Label` | `MostSevereInjuryType` | Options: Death, Serious Injury, Minor Injury, None/Unknown. Default: Death + Serious + Minor (None/Unknown hidden by default but can be toggled on). |
+| **Injury Severity** | Multi-select checkboxes | `Checkbox` + `Label` | `MostSevereInjuryType` | Options: Death, Major Injury, Minor Injury, None. Default: Death + Major + Minor (None hidden by default but can be toggled on). UI displays 4 buckets; resolver maps each to its constituent raw DB values (see Section 5 data notes). |
 
 **Cascading dropdowns:** State → County → City should filter progressively. This requires either client-side filtering of a metadata lookup or a lightweight query. See the metadata view below.
 
@@ -347,12 +347,12 @@ type Query {
 
 Crash points use a **severity-based color and opacity gradient** on the Mapbox circle layer. Bicyclist and pedestrian icons use slightly different hues but follow the same gradient system.
 
-| Severity | Color | Opacity | Size (base) | Default Visibility |
-| --- | --- | --- | --- | --- |
-| **Death** | Dark Red (`#B71C1C`) | ~85% | 8px | ✅ Shown |
-| **Serious Injury** | Orange (`#E65100`) | ~70% | 7px | ✅ Shown |
-| **Minor Injury** | Yellow (`#F9A825`) | ~55% | 6px | ✅ Shown |
-| **None / Unknown** | Pale Yellow-Green (`#C5E1A5`) | ~50% | 5px | ❌ Hidden by default |
+| Severity Bucket | Raw DB Values | Color | Opacity | Size (base) | Default Visibility |
+| --- | --- | --- | --- | --- | --- |
+| **Death** | "Dead at Scene", "Died in Hospital", "Dead on Arrival" | Dark Red (`#B71C1C`) | ~85% | 8px | ✅ Shown |
+| **Major Injury** | "Suspected Serious Injury" | Orange (`#E65100`) | ~70% | 7px | ✅ Shown |
+| **Minor Injury** | "Suspected Minor Injury", "Possible Injury" | Yellow (`#F9A825`) | ~55% | 6px | ✅ Shown |
+| **None** | "No Apparent Injury", "Unknown" | Pale Yellow-Green (`#C5E1A5`) | ~50% | 5px | ❌ Hidden by default |
 
 **Mapbox implementation** using data-driven styling:
 
@@ -369,21 +369,21 @@ map.addLayer({
       // At zoom 4 (state-level): small base sizes
       4, ['match', ['get', 'severity'],
         'Death',          3,
-        'Serious Injury', 2.5,
+        'Major Injury',   2.5,
         'Minor Injury',   2,
         /* None/Unknown */ 1.5
       ],
       // At zoom 10 (city-level): medium sizes
       10, ['match', ['get', 'severity'],
         'Death',          8,
-        'Serious Injury', 7,
+        'Major Injury',   7,
         'Minor Injury',   6,
         /* None/Unknown */ 5
       ],
       // At zoom 16 (street-level): large sizes
       16, ['match', ['get', 'severity'],
         'Death',          14,
-        'Serious Injury', 12,
+        'Major Injury',   12,
         'Minor Injury',   10,
         /* None/Unknown */ 8
       ]
@@ -391,14 +391,14 @@ map.addLayer({
     'circle-color': [
       'match', ['get', 'severity'],
       'Death',          '#B71C1C',
-      'Serious Injury', '#E65100',
+      'Major Injury',   '#E65100',
       'Minor Injury',   '#F9A825',
       /* None/Unknown */ '#C5E1A5'
     ],
     'circle-opacity': [
       'match', ['get', 'severity'],
       'Death',          0.85,
-      'Serious Injury', 0.70,
+      'Major Injury',   0.70,
       'Minor Injury',   0.55,
       /* None/Unknown */ 0.50
     ],
@@ -417,7 +417,7 @@ map.addLayer({
     ]
   },
   // Filter out None/Unknown by default
-  filter: ['in', 'severity', 'Death', 'Serious Injury', 'Minor Injury']
+  filter: ['in', 'severity', 'Death', 'Major Injury', 'Minor Injury']
 });
 ```
 
@@ -715,10 +715,10 @@ You're on Render's **Professional plan** (web services) with the **Basic Postgre
 - [x] Initialize Next.js project with TypeScript (`create-next-app --typescript`)
 - [x] Initialize Tailwind CSS and shadcn/ui (`npx shadcn-ui@latest init`)
 - [x] Set up PostgreSQL with PostGIS extension on your existing Render database (`CREATE EXTENSION postgis;`)
-- [ ] Run `prisma db pull` to introspect your existing `crashdata` table, then refine the generated Prisma model (see Section 3 for the recommended model)
-- [ ] Add the generated `geom` geometry column and create recommended indexes (see Section 3)
+- [x] Run `prisma db pull` to introspect your existing `crashdata` table, then refine the generated Prisma model (see Section 3 for the recommended model)
+- [x] Add the generated `geom` geometry column and create recommended indexes (see Section 3)
 - [x] Verify `FullDate` column format (ISO 8601: `2025-02-23T00:00:00`) and add `CrashDate` DATE column with index
-- [ ] Validate data: check for null `Latitude`/`Longitude` values, confirm `Mode` values are consistent ("Bicyclist"/"Pedestrian"), check `MostSevereInjuryType` distinct values
+- [x] Validate data: check for null `Latitude`/`Longitude` values, confirm `Mode` values are consistent ("Bicyclist"/"Pedestrian"), check `MostSevereInjuryType` distinct values
 - [ ] Create the `filter_metadata` and `available_years` materialized views (see Section 4) for cascading dropdown population
 - [ ] Set up ESLint, Prettier, Husky pre-commit hooks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,12 @@ CREATE TABLE public.crashdata
 
 - `FullDate` is stored as `text` in ISO 8601 format (`2025-02-23T00:00:00`). Use `CrashDate` (proper DATE column) for all date-range queries and filtering.
 - `Mode` values are "Bicyclist" or "Pedestrian"
-- `MostSevereInjuryType` values include: Death, Serious Injury, Minor Injury, None/Unknown
+- `MostSevereInjuryType` raw DB values and their 4-bucket display mapping:
+  - **Death**: "Dead at Scene", "Died in Hospital", "Dead on Arrival"
+  - **Major Injury**: "Suspected Serious Injury"
+  - **Minor Injury**: "Suspected Minor Injury", "Possible Injury"
+  - **None**: "No Apparent Injury", "Unknown"
+  - Additional values may appear as more data sources are imported — always map dynamically
 - Prisma model uses `@map` decorators to map camelCase TS properties to the existing PascalCase column names
 - A generated PostGIS `geom` column should be added for spatial queries (see ARCHITECTURE.md Section 3)
 
@@ -88,7 +93,7 @@ All filters are combinable (AND logic) and update the map in real time.
 | Mode | `ToggleGroup` | `Mode` |
 | Injury Severity (multi-select) | `Checkbox` + `Label` | `MostSevereInjuryType` |
 
-- None/Unknown injuries are **hidden by default** but can be toggled on
+- None injuries are **hidden by default** but can be toggled on
 - Cascading dropdowns powered by a `filter_metadata` materialized view
 - Year buttons show most recent 4 years as one-click shortcuts
 
@@ -96,12 +101,12 @@ All filters are combinable (AND logic) and update the map in real time.
 
 Severity-based visual hierarchy using color, opacity, AND size:
 
-| Severity | Color | Opacity | Base Size |
+| Severity Bucket | Color | Opacity | Base Size |
 | --- | --- | --- | --- |
 | Death | `#B71C1C` (dark red) | 85% | 8px |
-| Serious Injury | `#E65100` (orange) | 70% | 7px |
+| Major Injury | `#E65100` (orange) | 70% | 7px |
 | Minor Injury | `#F9A825` (yellow) | 55% | 6px |
-| None/Unknown | `#C5E1A5` (pale yellow-green) | 50% | 5px |
+| None | `#C5E1A5` (pale yellow-green) | 50% | 5px |
 
 - All sizes scale with zoom level via Mapbox `interpolate` expressions (small at state zoom, large at street zoom)
 - Stroke color differentiates mode: blue (`#1565C0`) for bicyclists, purple (`#4A148C`) for pedestrians
@@ -160,8 +165,8 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 ## What's Next (Phase 1 remaining)
 
-- [ ] Initialize Tailwind CSS and shadcn/ui (`npx shadcn-ui@latest init`)
-- [ ] Enable PostGIS on Render database (`CREATE EXTENSION postgis;`)
+- [x] Initialize Tailwind CSS and shadcn/ui (`npx shadcn-ui@latest init`)
+- [x] Enable PostGIS on Render database (`CREATE EXTENSION postgis;`)
 - [x] Run `prisma db pull` to introspect the existing `crashdata` table and refine the Prisma model
 - [ ] Add generated `geom` column and create indexes (see ARCHITECTURE.md Section 3)
 - [x] Verify `FullDate` format and add `CrashDate` DATE column with index

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.1.0
+**Version:** 0.1.1
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -57,6 +57,21 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Updated `.gitignore` with env file handling (`!.env.example`) and `prisma/migrations/`
 - Updated `ARCHITECTURE.md` and `CLAUDE.md` to reflect new `CrashDate` column across schema, Prisma model, GraphQL types, materialized views, and checklists
 - Added `tutorial.md` for step-by-step blog post draft
+
+### 2026-02-17 — Data Validation
+
+- Confirmed 1,315 rows with no null coordinates, no null `CrashDate`, all coordinates within US bounds
+- Normalized `Mode` value "Bicycle" → "Bicyclist" (543 rows updated)
+- Discovered `MostSevereInjuryType` has 8 raw values; defined 4 display buckets (Death, Major Injury, Minor Injury, None) with resolver-level mapping
+- Updated `ARCHITECTURE.md` and `CLAUDE.md` to reflect real severity values and bucket mapping ("Serious Injury" renamed to "Major Injury")
+
+### 2026-02-17 — PostGIS Geometry Column and Indexes
+
+- Added generated `geom geometry(Point, 4326)` column to `crashdata` (computed from `Latitude`/`Longitude`, STORED)
+- Created GIST spatial index (`idx_crashdata_geom`) for bounding-box and radius queries
+- Created B-tree indexes on `MostSevereInjuryType`, `Mode`, `StateOrProvinceName`, `CountyName`, `CityName`
+- Ran `prisma db pull` to pick up new column and indexes; `geom` represented as `Unsupported("geometry")` with GIST index captured as `type: Gist`
+- Ran `prisma generate` to regenerate typed client
 
 ### 2026-02-17 — Prisma Setup
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,25 +8,32 @@ datasource db {
 }
 
 model CrashData {
-  colliRptNum          String    @id @map("ColliRptNum")
-  jurisdiction         String?   @map("Jurisdiction")
-  stateOrProvinceName  String?   @map("StateOrProvinceName")
-  regionName           String?   @map("RegionName")
-  countyName           String?   @map("CountyName")
-  cityName             String?   @map("CityName")
-  fullDate             String?   @map("FullDate")
-  fullTime             String?   @map("FullTime")
-  mostSevereInjuryType String?   @map("MostSevereInjuryType")
-  ageGroup             String?   @map("AgeGroup")
-  involvedPersons      Int?      @map("InvolvedPersons") @db.SmallInt
-  crashStatePlaneX     Float?    @map("CrashStatePlaneX") @db.Real
-  crashStatePlaneY     Float?    @map("CrashStatePlaneY") @db.Real
-  latitude             Float?    @map("Latitude")
-  longitude            Float?    @map("Longitude")
-  mode                 String?   @map("Mode")
-  crashDate            DateTime? @map("CrashDate") @db.Date
+  colliRptNum          String                   @id @map("ColliRptNum")
+  jurisdiction         String?                  @map("Jurisdiction")
+  stateOrProvinceName  String?                  @map("StateOrProvinceName")
+  regionName           String?                  @map("RegionName")
+  countyName           String?                  @map("CountyName")
+  cityName             String?                  @map("CityName")
+  fullDate             String?                  @map("FullDate")
+  fullTime             String?                  @map("FullTime")
+  mostSevereInjuryType String?                  @map("MostSevereInjuryType")
+  ageGroup             String?                  @map("AgeGroup")
+  involvedPersons      Int?                     @map("InvolvedPersons") @db.SmallInt
+  crashStatePlaneX     Float?                   @map("CrashStatePlaneX") @db.Real
+  crashStatePlaneY     Float?                   @map("CrashStatePlaneY") @db.Real
+  latitude             Float?                   @map("Latitude")
+  longitude            Float?                   @map("Longitude")
+  mode                 String?                  @map("Mode")
+  crashDate            DateTime?                @map("CrashDate") @db.Date
+  geom                 Unsupported("geometry")? @default(dbgenerated("st_setsrid(st_makepoint(\"Longitude\", \"Latitude\"), 4326)"))
 
   @@index([crashDate], map: "idx_crashdata_date")
+  @@index([cityName], map: "idx_crashdata_city")
+  @@index([countyName], map: "idx_crashdata_county")
+  @@index([geom], map: "idx_crashdata_geom", type: Gist)
+  @@index([mode], map: "idx_crashdata_mode")
+  @@index([mostSevereInjuryType], map: "idx_crashdata_severity")
+  @@index([stateOrProvinceName], map: "idx_crashdata_state")
   @@map("crashdata")
 }
 


### PR DESCRIPTION
Add a generated PostGIS `geom` column and indexes to the Prisma schema (geom as Unsupported("geometry") with GIST index) and add B-tree indexes for common filters. Rename severity bucket from "Serious Injury" to "Major Injury" across docs and Mapbox expressions, and introduce a 4-bucket UI mapping (Death, Major Injury, Minor Injury, None) tied to raw DB values. Update map layer sizes, colors, opacity, and default filter to use the new bucket names. Bump README version and add release notes summarizing the data validation and PostGIS/index changes.