### PR TITLE
Add materialized views

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -719,7 +719,7 @@ You're on Render's **Professional plan** (web services) with the **Basic Postgre
 - [x] Add the generated `geom` geometry column and create recommended indexes (see Section 3)
 - [x] Verify `FullDate` column format (ISO 8601: `2025-02-23T00:00:00`) and add `CrashDate` DATE column with index
 - [x] Validate data: check for null `Latitude`/`Longitude` values, confirm `Mode` values are consistent ("Bicyclist"/"Pedestrian"), check `MostSevereInjuryType` distinct values
-- [ ] Create the `filter_metadata` and `available_years` materialized views (see Section 4) for cascading dropdown population
+- [x] Create the `filter_metadata` and `available_years` materialized views (see Section 4) for cascading dropdown population
 - [ ] Set up ESLint, Prettier, Husky pre-commit hooks
 
 **Deliverables:** Running Next.js app, populated database, Prisma client generated

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Updated `ARCHITECTURE.md` and `CLAUDE.md` to reflect new `CrashDate` column across schema, Prisma model, GraphQL types, materialized views, and checklists
 - Added `tutorial.md` for step-by-step blog post draft
 
+### 2026-02-17 — Materialized Views
+
+- Created `filter_metadata` materialized view (distinct state/county/city combinations) with `idx_filter_metadata_geo` index for cascading dropdown queries
+- Created `available_years` materialized view (distinct years from `CrashDate`)
+- Fixed import artifact: 51 King County, WA rows with `CityName = "'"` set to NULL; refreshed `filter_metadata`
+
 ### 2026-02-17 — Data Validation
 
 - Confirmed 1,315 rows with no null coordinates, no null `CrashDate`, all coordinates within US bounds


### PR DESCRIPTION
Mark materialized views as created in ARCHITECTURE.md and add documentation and tutorial content for two new Postgres materialized views: filter_metadata (state/county/city combos) with idx_filter_metadata_geo index, and available_years (distinct CrashDate years). Include SQL snippets for view creation, index, refresh commands, and a data-cleanup step that nulls 51 King County rows with CityName = "'". Also add a README changelog entry noting the views and import artifact fix.