### PR TITLE
Cache Next.js build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Lint
         run: npm run lint
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -774,7 +774,7 @@ You're on Render's **Professional plan** (web services) with the **Basic Postgre
 - [ ] Implement simple offset-based pagination
 - [ ] Add query depth limiting for public API protection
 - [ ] Write integration tests for all resolvers
-- [ ] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build) with branch protection on `main`
+- [ ] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build, `.next/cache` caching) with branch protection on `main`
 
 **Deliverables:** Fully tested GraphQL API accessible via Apollo Sandbox
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 - Created `.github/workflows/ci.yml` with lint, format check, typecheck, and build steps
 - Added `typecheck` script (`tsc --noEmit`) to `package.json`
+- Added `.next/cache` caching to CI workflow to eliminate Next.js build cache warning and speed up repeat builds
 
 ### 2026-02-17 — Linting & Formatting
 


### PR DESCRIPTION
Add a CI step to cache the Next.js build directory (.next/cache) using actions/cache@v4 to speed up repeated builds and remove the Next.js build cache warning. The cache key includes package-lock and source file hashes for accurate invalidation. Update README to document the new CI caching behavior.