### PR TITLE
Add GraphQL schema and stub resolvers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -764,8 +764,8 @@ You're on Render's **Professional plan** (web services) with the **Basic Postgre
 
 #### Milestone: Functional GraphQL API with core queries
 
-- [ ] Install Apollo Server and configure in `/app/api/graphql/route.ts`
-- [ ] Define GraphQL schema matching the types in Section 3:
+- [x] Install Apollo Server and configure in `/app/api/graphql/route.ts`
+- [x] Define GraphQL schema matching the types in Section 3:
   - Queries: `crashes(filter, limit, offset)`, `crash(colliRptNum)`, `crashStats(filter)`, `filterOptions`
   - Filters: by date/year, state, county, city, mode (Bicyclist/Pedestrian), severity (multi-select), bounding box
   - No mutations needed for public-facing app (add later if you build an admin interface)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Ran `prisma db pull` to pick up new column and indexes; `geom` represented as `Unsupported("geometry")` with GIST index captured as `type: Gist`
 - Ran `prisma generate` to regenerate typed client
 
+### 2026-02-17 — GraphQL Schema
+
+- Defined full GraphQL schema in `lib/graphql/typeDefs.ts`: `Crash`, `CrashResult`, `CrashStats`, `FilterOptions` types; `CrashFilter` and `BBoxInput` inputs; `crashes`, `crash`, `crashStats`, `filterOptions` queries
+- Added stub resolvers in `lib/graphql/resolvers.ts` (Prisma implementation next)
+- Updated `app/api/graphql/route.ts` to import from `lib/graphql/`
+
 ### 2026-02-17 — Apollo Server Setup
 
 - Installed `@apollo/server`, `graphql`, and `@as-integrations/next`

--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -1,18 +1,8 @@
 import { ApolloServer } from '@apollo/server'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import { NextRequest } from 'next/server'
-
-const typeDefs = `#graphql
-  type Query {
-    hello: String
-  }
-`
-
-const resolvers = {
-  Query: {
-    hello: () => 'Hello from CrashMap GraphQL!',
-  },
-}
+import { typeDefs } from '@/lib/graphql/typeDefs'
+import { resolvers } from '@/lib/graphql/resolvers'
 
 const server = new ApolloServer({ typeDefs, resolvers })
 

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -1,0 +1,27 @@
+// Stub resolvers — real Prisma implementations come in the next step.
+
+export const resolvers = {
+  Query: {
+    crashes: () => ({ items: [], totalCount: 0 }),
+    crash: () => null,
+    crashStats: () => ({
+      totalCrashes: 0,
+      totalFatal: 0,
+      byMode: [],
+      bySeverity: [],
+      byCounty: [],
+    }),
+    filterOptions: () => ({}),
+  },
+
+  // FilterOptions fields have their own arguments (for cascading dropdowns),
+  // so they need explicit resolvers on the type rather than just the Query level.
+  FilterOptions: {
+    states: () => [],
+    counties: () => [],
+    cities: () => [],
+    years: () => [],
+    severities: () => [],
+    modes: () => [],
+  },
+}

--- a/lib/graphql/typeDefs.ts
+++ b/lib/graphql/typeDefs.ts
@@ -1,0 +1,93 @@
+export const typeDefs = `#graphql
+  # ── Core crash record ───────────────────────────────────────────────────────
+
+  type Crash {
+    colliRptNum: ID!
+    jurisdiction: String
+    state: String
+    region: String
+    county: String
+    city: String
+    date: String        # Original FullDate text (ISO 8601)
+    crashDate: String   # Proper DATE column (YYYY-MM-DD)
+    time: String
+    severity: String    # Mapped display bucket: Death | Major Injury | Minor Injury | None
+    ageGroup: String
+    involvedPersons: Int
+    latitude: Float
+    longitude: Float
+    mode: String        # "Bicyclist" or "Pedestrian"
+  }
+
+  # ── Filters ──────────────────────────────────────────────────────────────────
+
+  input BBoxInput {
+    minLat: Float!
+    minLng: Float!
+    maxLat: Float!
+    maxLng: Float!
+  }
+
+  input CrashFilter {
+    severity: [String]          # Multi-select: ["Death", "Major Injury", ...]
+    mode: String                # "Bicyclist" | "Pedestrian"
+    state: String
+    county: String
+    city: String
+    dateFrom: String            # "YYYY-MM-DD" — used with dateTo for custom ranges
+    dateTo: String              # "YYYY-MM-DD"
+    year: Int                   # Shortcut: sets dateFrom/dateTo to full calendar year
+    bbox: BBoxInput             # Viewport-based spatial filter
+    includeNoInjury: Boolean    # Default false — opt-in to show None/Unknown severity
+  }
+
+  # ── Query return types ────────────────────────────────────────────────────────
+
+  type CrashResult {
+    items: [Crash!]!
+    totalCount: Int!
+  }
+
+  type ModeStat {
+    mode: String!
+    count: Int!
+  }
+
+  type SeverityStat {
+    severity: String!
+    count: Int!
+  }
+
+  type CountyStat {
+    county: String!
+    count: Int!
+  }
+
+  type CrashStats {
+    totalCrashes: Int!
+    totalFatal: Int!
+    byMode: [ModeStat!]!
+    bySeverity: [SeverityStat!]!
+    byCounty: [CountyStat!]!
+  }
+
+  # FilterOptions fields carry their own arguments to support cascading dropdowns:
+  # counties(state) returns only counties within the given state, etc.
+  type FilterOptions {
+    states: [String!]!
+    counties(state: String): [String!]!
+    cities(state: String, county: String): [String!]!
+    years: [Int!]!
+    severities: [String!]!
+    modes: [String!]!
+  }
+
+  # ── Queries ───────────────────────────────────────────────────────────────────
+
+  type Query {
+    crashes(filter: CrashFilter, limit: Int = 1000, offset: Int = 0): CrashResult!
+    crash(colliRptNum: ID!): Crash
+    crashStats(filter: CrashFilter): CrashStats!
+    filterOptions: FilterOptions!
+  }
+`

--- a/tutorial.md
+++ b/tutorial.md
@@ -711,12 +711,20 @@ const server = new ApolloServer({ typeDefs, resolvers })
 
 const handler = startServerAndCreateNextHandler<NextRequest>(server)
 
-export { handler as GET, handler as POST }
+export async function GET(request: NextRequest) {
+  return handler(request)
+}
+
+export async function POST(request: NextRequest) {
+  return handler(request)
+}
 ```
 
 The `#graphql` comment in the template literal is a convention that enables GraphQL syntax highlighting in editors that support it (VS Code with the GraphQL extension, for example).
 
 The `<NextRequest>` generic ensures the request type is properly inferred if you later add a `context` function to expose the request object to resolvers.
+
+> **Next.js 16 gotcha:** You might expect to write `export { handler as GET, handler as POST }` — but this fails to compile with Next.js 16, which requires route exports to be explicit `async function` signatures typed as `(request: NextRequest) => Promise<Response>`. The `@as-integrations/next` handler is overloaded to support both Pages Router and App Router, so re-exporting it directly fails the type check. Wrapping it in explicit async functions resolves the conflict.
 
 **Verify the endpoint:**
 


### PR DESCRIPTION
Move full GraphQL schema into lib/graphql/typeDefs.ts and add stub resolvers in lib/graphql/resolvers.ts. The schema defines Crash, CrashResult, CrashStats, FilterOptions types; CrashFilter and BBoxInput inputs; and queries crashes, crash, crashStats, and filterOptions. Update app/api/graphql/route.ts to import the new typeDefs and resolvers, and note the change in README. Prisma-backed resolver implementations will be added in a follow-up.