### PR TITLE
Implement Prisma GraphQL resolvers and client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 'on':
   push:
     branches: ['**']
-  pull_request:
-    branches: [main]
 
 jobs:
   check:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -739,111 +739,7 @@ You're on Render's **Professional plan** (web services) with the **Basic Postgre
 | **Performance regression testing** | Use k6 or Artillery for load testing; set query response time budgets (e.g., p95 < 200ms).                                                                             |
 | **Visual regression testing**      | Chromatic or Percy for chart snapshots. For Mapbox maps, snapshot testing is unreliable due to WebGL — use integration tests with `@mapbox/mapbox-gl-js-mock` instead. |
 
----
-
-## 8. Step-by-Step Action Plan
-
-### Phase 1: Foundation (Day 1)
-
-#### Milestone: Project scaffolding and data model\*\*
-
-- [x] Purchase domain: **crashmap.io** ✓
-- [x] Initialize Next.js project with TypeScript (`create-next-app --typescript`)
-- [x] Initialize Tailwind CSS and shadcn/ui (`npx shadcn-ui@latest init`)
-- [x] Set up PostgreSQL with PostGIS extension on your existing Render database (`CREATE EXTENSION postgis;`)
-- [x] Run `prisma db pull` to introspect your existing `crashdata` table, then refine the generated Prisma model (see Section 3 for the recommended model)
-- [x] Add the generated `geom` geometry column and create recommended indexes (see Section 3)
-- [x] Verify `FullDate` column format (ISO 8601: `2025-02-23T00:00:00`) and add `CrashDate` DATE column with index
-- [x] Validate data: check for null `Latitude`/`Longitude` values, confirm `Mode` values are consistent ("Bicyclist"/"Pedestrian"), check `MostSevereInjuryType` distinct values
-- [x] Create the `filter_metadata` and `available_years` materialized views (see Section 4) for cascading dropdown population
-- [x] Set up ESLint, Prettier, Husky pre-commit hooks
-
-**Deliverables:** Running Next.js app, populated database, Prisma client generated
-
-### Phase 2: API Layer (Week 1)
-
-#### Milestone: Functional GraphQL API with core queries
-
-- [x] Install Apollo Server and configure in `/app/api/graphql/route.ts`
-- [x] Define GraphQL schema matching the types in Section 3:
-  - Queries: `crashes(filter, limit, offset)`, `crash(colliRptNum)`, `crashStats(filter)`, `filterOptions`
-  - Filters: by date/year, state, county, city, mode (Bicyclist/Pedestrian), severity (multi-select), bounding box
-  - No mutations needed for public-facing app (add later if you build an admin interface)
-- [ ] Implement resolvers with Prisma (single-table queries — straightforward)
-- [ ] Set up `graphql-codegen` for automatic TypeScript type generation
-- [ ] Implement simple offset-based pagination
-- [ ] Add query depth limiting for public API protection
-- [ ] Write integration tests for all resolvers
-- [ ] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build, `.next/cache` caching) with branch protection on `main`
-
-**Deliverables:** Fully tested GraphQL API accessible via Apollo Sandbox
-
-### Phase 3: Frontend Core (Weeks 2-3)
-
-#### Milestone: Interactive map with filters
-
-- [ ] Set up Apollo Client with InMemoryCache and type policies
-- [ ] Install shadcn/ui components needed for the UI:
-  - `npx shadcn-ui@latest add button select checkbox toggle-group sheet dialog badge popover calendar`
-- [ ] Build interactive map component with Mapbox GL JS (`react-map-gl`):
-  - GeoJSON source built from `Latitude`/`Longitude` fields
-  - Circle layer with severity-based color/opacity gradient (see Section 4 for palette)
-  - Stroke color differentiation for bicyclist vs. pedestrian mode
-  - None/Unknown injuries hidden by default via Mapbox layer filter
-  - Heatmap layer for density visualization at low zoom levels
-  - Built-in clustering with `cluster: true` on the GeoJSON source
-  - Popup/tooltip on click showing crash details (date, severity, mode, location, age group)
-- [ ] Secure Mapbox access token via environment variable (`NEXT_PUBLIC_MAPBOX_TOKEN`)
-- [ ] Implement filter panel (see Section 4 for full spec):
-  - Date Range: year quick-select buttons (most recent 4 years) + custom date range picker
-  - State → County → City cascading dropdowns (powered by `filter_metadata` view)
-  - Mode toggle: Bicyclist / Pedestrian / All
-  - Severity multi-select: Death, Serious, Minor (None/Unknown opt-in)
-- [ ] Load filter options on app init via `filterOptions` GraphQL query
-- [ ] Connect filters to GraphQL query variables
-- [ ] Implement mobile-first responsive layout (see Section 4 — UI Layout):
-  - Full-viewport map as the base layer on all screen sizes
-  - Mobile: floating overlay controls + full-screen filter overlay (toggle open/close)
-  - Desktop: toggleable right sidebar (~320px) for filters
-  - Persistent summary bar showing crash count and active filter chips
-  - Call `map.resize()` on sidebar open/close transitions
-
-**Deliverables:** Working app with map and filters
-
-### Phase 4: Security, Polish & Deployment (Weeks TBD)
-
-#### Milestone: Production-ready public application
-
-- [ ] Add rate limiting middleware for public API abuse prevention
-- [ ] Configure CSP headers and CORS in Next.js
-- [ ] Add loading states, error boundaries, skeleton screens
-- [ ] Implement URL-based state for shareable filter configurations (e.g., `?severity=Death&mode=Pedestrian&state=Ohio&county=Franklin`)
-- [ ] Add data export (CSV/PDF) for filtered results
-- [ ] Accessibility audit (WCAG 2.1 AA)
-- [ ] Add a data disclaimer, methodology page, and links to bicycle/pedestrian safety resources
-- [ ] Deploy to Render with staging and production environments (Web Service for Next.js app, existing PostgreSQL database)
-- [ ] Configure custom domain `crashmap.io` in Render and set up DNS records
-- [ ] Configure Render auto-deploy from your GitHub repo's `main` branch
-- [ ] Set up CI/CD pipeline (GitHub Actions):
-  - Lint → Type check → Test → Codegen → Build → Deploy
-- [ ] Configure basic monitoring (Sentry for errors, Lighthouse CI for web vitals)
-
-**Deliverables:** Deployed, public-facing production application
-
-### Phase 5: Iteration (Ongoing)
-
-- [ ] Gather user feedback and iterate on visualizations
-- [ ] **Stretch goal: Dashboard charts** (see Section 11) — add Recharts/D3 visualizations for severity, mode, time trends, and geographic breakdowns
-- [ ] **Stretch goal: Mobile bottom sheet** (see Section 11) — upgrade from full-screen overlay using `vaul` or `react-modal-sheet` for peek/half/full snap states
-- [ ] **Stretch goal: Light/Dark mode** (see Section 11) — swap Mapbox basemap, chart themes, and UI via CSS custom properties
-- [ ] Add comparative analysis features (year-over-year, area comparison)
-- [ ] Add an admin interface for uploading new crash data (protected with NextAuth.js)
-- [ ] Monitor query performance — add materialized views only if aggregation queries become slow
-- [ ] If data grows beyond 50K rows or traffic increases, revisit the caching strategy
-
----
-
-## 9. Recommended Tools & Resources
+## 8. Recommended Tools & Resources
 
 ### Core Stack Libraries
 
@@ -895,7 +791,7 @@ You're on Render's **Professional plan** (web services) with the **Basic Postgre
 
 ---
 
-## 10. Evaluating Architecture Effectiveness
+## 9. Evaluating Architecture Effectiveness
 
 ### Key Metrics to Track
 
@@ -924,7 +820,7 @@ Given low daily traffic, a lightweight evaluation approach is appropriate:
 
 ---
 
-## 11. Stretch Goals
+## 10. Stretch Goals
 
 ### Dashboard Charts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - **Map:** Mapbox GL JS via `react-map-gl`
 - **API:** Apollo Server integrated into Next.js API route (`/app/api/graphql`)
 - **GraphQL Client:** Apollo Client with InMemoryCache
-- **ORM:** Prisma (use `prisma db pull` to introspect existing table — do NOT use `prisma migrate dev`)
+- **ORM:** Prisma 7 with `provider = "prisma-client"` generator and `@prisma/adapter-pg` driver adapter (use `prisma db pull` to introspect existing table — do NOT use `prisma migrate dev`)
 - **Database:** PostgreSQL + PostGIS on Render (Basic plan, 5GB)
 - **Hosting:** Render — Professional plan (web service), Basic plan (database)
 - **Domain:** crashmap.io (purchased)
@@ -59,7 +59,21 @@ CREATE TABLE public.crashdata
   - **None**: "No Apparent Injury", "Unknown"
   - Additional values may appear as more data sources are imported — always map dynamically
 - Prisma model uses `@map` decorators to map camelCase TS properties to the existing PascalCase column names
-- A generated PostGIS `geom` column should be added for spatial queries (see ARCHITECTURE.md Section 3)
+- A generated PostGIS `geom` column exists for spatial queries (see ARCHITECTURE.md Section 3)
+
+### Prisma 7 Client Notes
+
+- Generator: `provider = "prisma-client"` (new WASM-based compiler, NOT the legacy `prisma-client-js`)
+- Generated output: `lib/generated/prisma/` (gitignored — regenerated via `postinstall: prisma generate`)
+- **Import path:** `@/lib/generated/prisma/client` (no bare `index.ts` — use `/client` suffix)
+- **Constructor requires a driver adapter** — `new PrismaClient()` with no args will not type-check. Use:
+
+  ```ts
+  import { PrismaPg } from '@prisma/adapter-pg'
+  new PrismaClient({ adapter: new PrismaPg(process.env.DATABASE_URL!) })
+  ```
+
+- Prisma singleton lives in `lib/prisma.ts`; use `globalThis` pattern to prevent connection pool exhaustion in dev hot reloads
 
 ### Data Scale & Traffic
 
@@ -153,7 +167,12 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - `ARCHITECTURE.md` — Full architecture document with data model, GraphQL schema, Prisma model, SQL indexes, action plan, and all technical details
 - `tutorial.md` — Step-by-step tutorial draft for blog post
 - `README.md` — Project readme with changelog at the bottom
-- Prisma schema should use `@@map("crashdata")` and `@map("ColumnName")` for each field
+- `prisma/schema.prisma` — Prisma schema (introspected via `prisma db pull`; do NOT run `prisma migrate dev`)
+- `lib/prisma.ts` — PrismaClient singleton (with `@prisma/adapter-pg`)
+- `lib/graphql/typeDefs.ts` — Full GraphQL schema (SDL string)
+- `lib/graphql/resolvers.ts` — All resolvers with severity bucket mapping and `buildWhere` helper
+- `app/api/graphql/route.ts` — Apollo Server route handler
+- `lib/generated/prisma/` — Generated Prisma client (gitignored; regenerated via `postinstall: prisma generate`)
 
 ## What's Done
 
@@ -163,11 +182,106 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Render Basic PostgreSQL (5GB) with data loaded
 - [x] Architecture document complete
 
-## What's Next (Phase 1 remaining)
+---
 
+## 8. Step-by-Step Action Plan
+
+### Phase 1: Foundation (Day 1)
+
+#### Milestone: Project scaffolding and data model\*\*
+
+- [x] Purchase domain: **crashmap.io** ✓
+- [x] Initialize Next.js project with TypeScript (`create-next-app --typescript`)
 - [x] Initialize Tailwind CSS and shadcn/ui (`npx shadcn-ui@latest init`)
-- [x] Enable PostGIS on Render database (`CREATE EXTENSION postgis;`)
-- [x] Run `prisma db pull` to introspect the existing `crashdata` table and refine the Prisma model
-- [ ] Add generated `geom` column and create indexes (see ARCHITECTURE.md Section 3)
-- [x] Verify `FullDate` format and add `CrashDate` DATE column with index
-- [ ] Set up ESLint, Prettier, Husky pre-commit hooks
+- [x] Set up PostgreSQL with PostGIS extension on your existing Render database (`CREATE EXTENSION postgis;`)
+- [x] Run `prisma db pull` to introspect your existing `crashdata` table, then refine the generated Prisma model (see Section 3 for the recommended model)
+- [x] Add the generated `geom` geometry column and create recommended indexes (see Section 3)
+- [x] Verify `FullDate` column format (ISO 8601: `2025-02-23T00:00:00`) and add `CrashDate` DATE column with index
+- [x] Validate data: check for null `Latitude`/`Longitude` values, confirm `Mode` values are consistent ("Bicyclist"/"Pedestrian"), check `MostSevereInjuryType` distinct values
+- [x] Create the `filter_metadata` and `available_years` materialized views (see Section 4) for cascading dropdown population
+- [x] Set up ESLint, Prettier, Husky pre-commit hooks
+
+**Deliverables:** Running Next.js app, populated database, Prisma client generated
+
+### Phase 2: API Layer (Week 1)
+
+#### Milestone: Functional GraphQL API with core queries
+
+- [x] Install Apollo Server and configure in `/app/api/graphql/route.ts`
+- [x] Define GraphQL schema matching the types in Section 3:
+  - Queries: `crashes(filter, limit, offset)`, `crash(colliRptNum)`, `crashStats(filter)`, `filterOptions`
+  - Filters: by date/year, state, county, city, mode (Bicyclist/Pedestrian), severity (multi-select), bounding box
+  - No mutations needed for public-facing app (add later if you build an admin interface)
+- [x] Implement resolvers with Prisma (single-table queries — straightforward)
+- [ ] Set up `graphql-codegen` for automatic TypeScript type generation
+- [ ] Implement simple offset-based pagination
+- [ ] Add query depth limiting for public API protection
+- [ ] Write integration tests for all resolvers
+- [ ] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build, `.next/cache` caching) with branch protection on `main`
+
+**Deliverables:** Fully tested GraphQL API accessible via Apollo Sandbox
+
+### Phase 3: Frontend Core (Weeks 2-3)
+
+#### Milestone: Interactive map with filters
+
+- [ ] Set up Apollo Client with InMemoryCache and type policies
+- [ ] Install shadcn/ui components needed for the UI:
+  - `npx shadcn-ui@latest add button select checkbox toggle-group sheet dialog badge popover calendar`
+- [ ] Build interactive map component with Mapbox GL JS (`react-map-gl`):
+  - GeoJSON source built from `Latitude`/`Longitude` fields
+  - Circle layer with severity-based color/opacity gradient (see Section 4 for palette)
+  - Stroke color differentiation for bicyclist vs. pedestrian mode
+  - None/Unknown injuries hidden by default via Mapbox layer filter
+  - Heatmap layer for density visualization at low zoom levels
+  - Built-in clustering with `cluster: true` on the GeoJSON source
+  - Popup/tooltip on click showing crash details (date, severity, mode, location, age group)
+- [ ] Secure Mapbox access token via environment variable (`NEXT_PUBLIC_MAPBOX_TOKEN`)
+- [ ] Implement filter panel (see Section 4 for full spec):
+  - Date Range: year quick-select buttons (most recent 4 years) + custom date range picker
+  - State → County → City cascading dropdowns (powered by `filter_metadata` view)
+  - Mode toggle: Bicyclist / Pedestrian / All
+  - Severity multi-select: Death, Serious, Minor (None/Unknown opt-in)
+- [ ] Load filter options on app init via `filterOptions` GraphQL query
+- [ ] Connect filters to GraphQL query variables
+- [ ] Implement mobile-first responsive layout (see Section 4 — UI Layout):
+  - Full-viewport map as the base layer on all screen sizes
+  - Mobile: floating overlay controls + full-screen filter overlay (toggle open/close)
+  - Desktop: toggleable right sidebar (~320px) for filters
+  - Persistent summary bar showing crash count and active filter chips
+  - Call `map.resize()` on sidebar open/close transitions
+
+**Deliverables:** Working app with map and filters
+
+### Phase 4: Security, Polish & Deployment (Weeks TBD)
+
+#### Milestone: Production-ready public application
+
+- [ ] Add rate limiting middleware for public API abuse prevention
+- [ ] Configure CSP headers and CORS in Next.js
+- [ ] Add loading states, error boundaries, skeleton screens
+- [ ] Implement URL-based state for shareable filter configurations (e.g., `?severity=Death&mode=Pedestrian&state=Ohio&county=Franklin`)
+- [ ] Add data export (CSV/PDF) for filtered results
+- [ ] Accessibility audit (WCAG 2.1 AA)
+- [ ] Add a data disclaimer, methodology page, and links to bicycle/pedestrian safety resources
+- [ ] Deploy to Render with staging and production environments (Web Service for Next.js app, existing PostgreSQL database)
+- [ ] Configure custom domain `crashmap.io` in Render and set up DNS records
+- [ ] Configure Render auto-deploy from your GitHub repo's `main` branch
+- [ ] Set up CI/CD pipeline (GitHub Actions):
+  - Lint → Type check → Test → Codegen → Build → Deploy
+- [ ] Configure basic monitoring (Sentry for errors, Lighthouse CI for web vitals)
+
+**Deliverables:** Deployed, public-facing production application
+
+### Phase 5: Iteration (Ongoing)
+
+- [ ] Gather user feedback and iterate on visualizations
+- [ ] **Stretch goal: Dashboard charts** (see Section 11) — add Recharts/D3 visualizations for severity, mode, time trends, and geographic breakdowns
+- [ ] **Stretch goal: Mobile bottom sheet** (see Section 11) — upgrade from full-screen overlay using `vaul` or `react-modal-sheet` for peek/half/full snap states
+- [ ] **Stretch goal: Light/Dark mode** (see Section 11) — swap Mapbox basemap, chart themes, and UI via CSS custom properties
+- [ ] Add comparative analysis features (year-over-year, area comparison)
+- [ ] Add an admin interface for uploading new crash data (protected with NextAuth.js)
+- [ ] Monitor query performance — add materialized views only if aggregation queries become slow
+- [ ] If data grows beyond 50K rows or traffic increases, revisit the caching strategy
+
+---

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Ran `prisma db pull` to pick up new column and indexes; `geom` represented as `Unsupported("geometry")` with GIST index captured as `type: Gist`
 - Ran `prisma generate` to regenerate typed client
 
+### 2026-02-17 — GraphQL Resolvers
+
+- Implemented full Prisma resolvers in `lib/graphql/resolvers.ts`: `crashes`, `crash`, `crashStats`, `filterOptions` queries
+- Added severity bucket mapping (`Death`/`Major Injury`/`Minor Injury`/`None`) with `rawToBucket` and `bucketsToRawValues` helpers
+- Added `buildWhere` helper translating `CrashFilter` input to Prisma where clauses (mode, geography, date range, year shortcut, bbox, severity, `includeNoInjury`)
+- `FilterOptions` field resolvers query `filter_metadata` and `available_years` materialized views via `$queryRaw`
+- Created `lib/prisma.ts` singleton with `@prisma/adapter-pg` (required by Prisma 7's new `prisma-client` generator)
+- Added `"postinstall": "prisma generate"` to `package.json` so CI generates the client after `npm ci`
+- Installed `@prisma/adapter-pg`
+
 ### 2026-02-17 — GraphQL Schema
 
 - Defined full GraphQL schema in `lib/graphql/typeDefs.ts`: `Crash`, `CrashResult`, `CrashStats`, `FilterOptions` types; `CrashFilter` and `BBoxInput` inputs; `crashes`, `crash`, `crashStats`, `filterOptions` queries

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -1,27 +1,257 @@
-// Stub resolvers — real Prisma implementations come in the next step.
+import { prisma } from '@/lib/prisma'
+
+// ── Severity bucket mapping ───────────────────────────────────────────────────
+// Maps display bucket names to their raw DB values in MostSevereInjuryType.
+// New raw values from future data imports will fall through to rawToBucket's
+// passthrough return, so they render as-is rather than silently disappearing.
+
+const SEVERITY_BUCKETS: Record<string, string[]> = {
+  Death: ['Dead at Scene', 'Died in Hospital', 'Dead on Arrival'],
+  'Major Injury': ['Suspected Serious Injury'],
+  'Minor Injury': ['Suspected Minor Injury', 'Possible Injury'],
+  None: ['No Apparent Injury', 'Unknown'],
+}
+
+const NONE_VALUES = SEVERITY_BUCKETS['None']
+
+function rawToBucket(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  for (const [bucket, values] of Object.entries(SEVERITY_BUCKETS)) {
+    if (values.includes(raw)) return bucket
+  }
+  return raw // unmapped value — pass through as-is
+}
+
+// Expand display bucket names to the raw DB values they represent.
+function bucketsToRawValues(buckets: string[]): string[] {
+  return buckets.flatMap((b) => SEVERITY_BUCKETS[b] ?? [b])
+}
+
+// ── Filter input type ─────────────────────────────────────────────────────────
+
+interface CrashFilterInput {
+  severity?: string[] | null
+  mode?: string | null
+  state?: string | null
+  county?: string | null
+  city?: string | null
+  dateFrom?: string | null
+  dateTo?: string | null
+  year?: number | null
+  bbox?: { minLat: number; minLng: number; maxLat: number; maxLng: number } | null
+  includeNoInjury?: boolean | null
+}
+
+// ── Build Prisma where clause from GraphQL filter input ───────────────────────
+
+function buildWhere(filter?: CrashFilterInput | null) {
+  const { severity, mode, state, county, city, dateFrom, dateTo, year, bbox, includeNoInjury } =
+    filter ?? {}
+
+  // Severity: if buckets specified, expand to raw values; otherwise exclude None by default.
+  let severityWhere = {}
+  if (severity && severity.length > 0) {
+    severityWhere = { mostSevereInjuryType: { in: bucketsToRawValues(severity) } }
+  } else if (!includeNoInjury) {
+    severityWhere = { mostSevereInjuryType: { notIn: NONE_VALUES } }
+  }
+
+  // Date range: year shortcut takes precedence over dateFrom/dateTo.
+  let dateWhere = {}
+  if (year) {
+    dateWhere = {
+      crashDate: { gte: new Date(`${year}-01-01`), lte: new Date(`${year}-12-31`) },
+    }
+  } else if (dateFrom || dateTo) {
+    dateWhere = {
+      crashDate: {
+        ...(dateFrom ? { gte: new Date(dateFrom) } : {}),
+        ...(dateTo ? { lte: new Date(dateTo) } : {}),
+      },
+    }
+  }
+
+  // Bounding box: lat/lng column range query.
+  const bboxWhere = bbox
+    ? {
+        latitude: { gte: bbox.minLat, lte: bbox.maxLat },
+        longitude: { gte: bbox.minLng, lte: bbox.maxLng },
+      }
+    : {}
+
+  return {
+    ...(mode ? { mode } : {}),
+    ...(state ? { stateOrProvinceName: state } : {}),
+    ...(county ? { countyName: county } : {}),
+    ...(city ? { cityName: city } : {}),
+    ...dateWhere,
+    ...bboxWhere,
+    ...severityWhere,
+  }
+}
+
+// ── Crash field parent type ───────────────────────────────────────────────────
+// GraphQL Crash fields that differ from Prisma field names need explicit
+// resolvers. This type captures just the fields those resolvers read.
+// Codegen (next step) will replace this with generated types.
+
+interface CrashParent {
+  stateOrProvinceName: string | null
+  regionName: string | null
+  countyName: string | null
+  cityName: string | null
+  fullDate: string | null
+  fullTime: string | null
+  mostSevereInjuryType: string | null
+  crashDate: Date | null
+}
+
+// ── Resolvers ─────────────────────────────────────────────────────────────────
 
 export const resolvers = {
   Query: {
-    crashes: () => ({ items: [], totalCount: 0 }),
-    crash: () => null,
-    crashStats: () => ({
-      totalCrashes: 0,
-      totalFatal: 0,
-      byMode: [],
-      bySeverity: [],
-      byCounty: [],
-    }),
+    crashes: async (
+      _: unknown,
+      {
+        filter,
+        limit = 1000,
+        offset = 0,
+      }: { filter?: CrashFilterInput | null; limit?: number; offset?: number }
+    ) => {
+      const where = buildWhere(filter)
+      const [items, totalCount] = await Promise.all([
+        prisma.crashData.findMany({ where, skip: offset, take: limit }),
+        prisma.crashData.count({ where }),
+      ])
+      return { items, totalCount }
+    },
+
+    crash: async (_: unknown, { colliRptNum }: { colliRptNum: string }) =>
+      prisma.crashData.findUnique({ where: { colliRptNum } }),
+
+    crashStats: async (_: unknown, { filter }: { filter?: CrashFilterInput | null }) => {
+      const where = buildWhere(filter)
+      const deathValues = SEVERITY_BUCKETS['Death']
+
+      const [totalCrashes, totalFatal, modeGroups, severityGroups, countyGroups] =
+        await Promise.all([
+          prisma.crashData.count({ where }),
+          prisma.crashData.count({
+            where: { ...where, mostSevereInjuryType: { in: deathValues } },
+          }),
+          prisma.crashData.groupBy({ by: ['mode'], where, _count: { _all: true } }),
+          prisma.crashData.groupBy({
+            by: ['mostSevereInjuryType'],
+            where,
+            _count: { _all: true },
+          }),
+          prisma.crashData.groupBy({
+            by: ['countyName'],
+            where,
+            _count: { _all: true },
+            orderBy: { _count: { countyName: 'desc' } },
+          }),
+        ])
+
+      // Multiple raw DB values share a bucket (e.g. "Dead at Scene" + "Died in Hospital" → "Death").
+      // Sum counts by bucket before returning.
+      const bucketTotals = new Map<string, number>()
+      for (const g of severityGroups) {
+        const bucket = rawToBucket(g.mostSevereInjuryType) ?? 'Unknown'
+        bucketTotals.set(bucket, (bucketTotals.get(bucket) ?? 0) + g._count._all)
+      }
+
+      return {
+        totalCrashes,
+        totalFatal,
+        byMode: modeGroups.map((g) => ({ mode: g.mode ?? 'Unknown', count: g._count._all })),
+        bySeverity: Array.from(bucketTotals.entries()).map(([severity, count]) => ({
+          severity,
+          count,
+        })),
+        byCounty: countyGroups.map((g) => ({
+          county: g.countyName ?? 'Unknown',
+          count: g._count._all,
+        })),
+      }
+    },
+
+    // filterOptions returns an empty object — the real data is resolved field-by-field below.
     filterOptions: () => ({}),
   },
 
-  // FilterOptions fields have their own arguments (for cascading dropdowns),
-  // so they need explicit resolvers on the type rather than just the Query level.
+  // ── Crash field resolvers ─────────────────────────────────────────────────
+  // Only fields where the GraphQL name differs from the Prisma field name (or
+  // where a type transform is needed) require explicit resolvers. All other
+  // fields (colliRptNum, jurisdiction, latitude, longitude, mode, etc.) resolve
+  // automatically by name match.
+
+  Crash: {
+    state: (p: CrashParent) => p.stateOrProvinceName,
+    region: (p: CrashParent) => p.regionName,
+    county: (p: CrashParent) => p.countyName,
+    city: (p: CrashParent) => p.cityName,
+    date: (p: CrashParent) => p.fullDate,
+    time: (p: CrashParent) => p.fullTime,
+    severity: (p: CrashParent) => rawToBucket(p.mostSevereInjuryType),
+    // crashDate is a Date object from Prisma — format as YYYY-MM-DD string.
+    crashDate: (p: CrashParent) => p.crashDate?.toISOString().slice(0, 10) ?? null,
+  },
+
+  // ── FilterOptions field resolvers ─────────────────────────────────────────
+  // These query the filter_metadata and available_years materialized views.
+  // Field-level arguments (e.g. counties(state)) are passed as the second arg.
+
   FilterOptions: {
-    states: () => [],
-    counties: () => [],
-    cities: () => [],
-    years: () => [],
-    severities: () => [],
-    modes: () => [],
+    states: async () => {
+      const rows = await prisma.$queryRaw<{ state: string }[]>`
+        SELECT DISTINCT state FROM filter_metadata WHERE state IS NOT NULL ORDER BY state
+      `
+      return rows.map((r) => r.state)
+    },
+
+    counties: async (_: unknown, { state }: { state?: string | null }) => {
+      const rows = state
+        ? await prisma.$queryRaw<{ county: string }[]>`
+            SELECT DISTINCT county FROM filter_metadata
+            WHERE state = ${state} AND county IS NOT NULL ORDER BY county
+          `
+        : await prisma.$queryRaw<{ county: string }[]>`
+            SELECT DISTINCT county FROM filter_metadata WHERE county IS NOT NULL ORDER BY county
+          `
+      return rows.map((r) => r.county)
+    },
+
+    cities: async (
+      _: unknown,
+      { state, county }: { state?: string | null; county?: string | null }
+    ) => {
+      const rows =
+        state && county
+          ? await prisma.$queryRaw<{ city: string }[]>`
+              SELECT DISTINCT city FROM filter_metadata
+              WHERE state = ${state} AND county = ${county} AND city IS NOT NULL ORDER BY city
+            `
+          : state
+            ? await prisma.$queryRaw<{ city: string }[]>`
+                SELECT DISTINCT city FROM filter_metadata
+                WHERE state = ${state} AND city IS NOT NULL ORDER BY city
+              `
+            : await prisma.$queryRaw<{ city: string }[]>`
+                SELECT DISTINCT city FROM filter_metadata WHERE city IS NOT NULL ORDER BY city
+              `
+      return rows.map((r) => r.city)
+    },
+
+    years: async () => {
+      const rows = await prisma.$queryRaw<{ year: number }[]>`
+        SELECT year FROM available_years ORDER BY year DESC
+      `
+      return rows.map((r) => Number(r.year))
+    },
+
+    severities: () => ['Death', 'Major Injury', 'Minor Injury', 'None'],
+
+    modes: () => ['Bicyclist', 'Pedestrian'],
   },
 }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from '@/lib/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+// Singleton pattern prevents exhausting connection pool during Next.js hot reloads in dev.
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined }
+
+function createPrismaClient() {
+  const adapter = new PrismaPg(process.env.DATABASE_URL!)
+  return new PrismaClient({ adapter })
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "crashmap",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@apollo/server": "^5.4.0",
         "@as-integrations/next": "^4.1.0",
+        "@prisma/adapter-pg": "^7.4.0",
         "@prisma/client": "^7.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2385,6 +2387,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.4.0.tgz",
+      "integrity": "sha512-LWwTHaio0bMxvzahmpwpWqsZM0vTfMqwF8zo06YvILL/o47voaSfKzCVxZw/o9awf4fRgS5Vgthobikj9Dusaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.4.0",
+        "pg": "^8.16.3",
+        "postgres-array": "3.0.4"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.4.0.tgz",
@@ -2432,7 +2445,6 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.0.tgz",
       "integrity": "sha512-fZicwzgFHvvPMrRLCUinrsBTdadJsi/1oirzShjmFvNLwtu2DYlkxwRVy5zEGhp85mrEGnLeS/PdNRCdE027+Q==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
@@ -2469,6 +2481,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.4.0.tgz",
+      "integrity": "sha512-jEyE5LkqZ27Ba/DIOfCGOQl6nKMLxuwJNRceCfh7/LRs46UkIKn3bmkI97MEH2t7zkYV3PGBrUr+6sMJaHvc0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.0"
       }
     },
     "node_modules/@prisma/engines": {
@@ -10755,6 +10776,104 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10873,6 +10992,45 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/powershell-utils": {
@@ -12140,6 +12298,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -13341,6 +13508,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
+    "postinstall": "prisma generate",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -24,6 +25,7 @@
   "dependencies": {
     "@apollo/server": "^5.4.0",
     "@as-integrations/next": "^4.1.0",
+    "@prisma/adapter-pg": "^7.4.0",
     "@prisma/client": "^7.4.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Add full Prisma-backed GraphQL resolvers and a Prisma client singleton. Implemented queries: crashes, crash, crashStats, and filterOptions; added severity bucket mapping with helpers (rawToBucket, bucketsToRawValues) and buildWhere to translate CrashFilter input into Prisma where clauses (mode, geography, date range/year, bbox, severity, includeNoInjury). crashStats aggregates counts (including bucketed severity totals) and crashes uses findMany/count. Added Crash field resolvers to map/format Prisma fields (state, region, county, city, date, time, severity, crashDate). FilterOptions fields query materialized views via $queryRaw. Created lib/prisma.ts using @prisma/adapter-pg for Prisma 7 and added a postinstall script and dependency in package.json; updated README to document the changes.