### PR TITLE
Add GraphQL depth limit and pagination cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,9 +213,9 @@ Severity-based visual hierarchy using color, opacity, AND size:
   - Filters: by date/year, state, county, city, mode (Bicyclist/Pedestrian), severity (multi-select), bounding box
   - No mutations needed for public-facing app (add later if you build an admin interface)
 - [x] Implement resolvers with Prisma (single-table queries — straightforward)
-- [ ] Set up `graphql-codegen` for automatic TypeScript type generation
-- [ ] Implement simple offset-based pagination
-- [ ] Add query depth limiting for public API protection
+- [x] Set up `graphql-codegen` for automatic TypeScript type generation
+- [x] Implement simple offset-based pagination
+- [x] Add query depth limiting for public API protection
 - [ ] Write integration tests for all resolvers
 - [ ] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build, `.next/cache` caching) with branch protection on `main`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.2.1
+**Version:** 0.2.2
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -103,6 +103,16 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Created `lib/prisma.ts` singleton with `@prisma/adapter-pg` (required by Prisma 7's new `prisma-client` generator)
 - Added `"postinstall": "prisma generate"` to `package.json` so CI generates the client after `npm ci`
 - Installed `@prisma/adapter-pg`
+
+### 2026-02-17 — Query Depth Limiting
+
+- Added inline `depthLimitRule` validation rule to Apollo Server in `app/api/graphql/route.ts` (max depth: 5)
+- No external dependency — rule walks the AST using graphql-js built-in types (`ValidationRule`, `ValidationContext`, `ASTNode`)
+
+### 2026-02-17 — Pagination
+
+- `crashes` query already had `limit`/`offset` args and `CrashResult.totalCount` from initial schema design; confirmed offset-based pagination is fully functional
+- Added server-side `limit` cap of 5000 in resolver to prevent unbounded queries (`Math.min(limit ?? 1000, 5000)`)
 
 ### 2026-02-17 — GraphQL Codegen
 

--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -1,10 +1,40 @@
 import { ApolloServer } from '@apollo/server'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
+import { GraphQLError, ValidationContext } from 'graphql'
+import type { ASTNode, ValidationRule } from 'graphql'
 import { NextRequest } from 'next/server'
 import { typeDefs } from '@/lib/graphql/typeDefs'
 import { resolvers } from '@/lib/graphql/resolvers'
 
-const server = new ApolloServer({ typeDefs, resolvers })
+// ── Query depth limiting ──────────────────────────────────────────────────────
+// Rejects queries deeper than MAX_DEPTH before they reach any resolver.
+// Our schema is shallow (max legitimate depth ≈ 3), so 5 leaves ample headroom.
+
+const MAX_DEPTH = 5
+
+function queryDepth(node: ASTNode, depth = 0): number {
+  if ('selectionSet' in node && node.selectionSet) {
+    const sels = (node.selectionSet as { selections: readonly ASTNode[] }).selections
+    if (sels.length === 0) return depth
+    return Math.max(...sels.map((s) => queryDepth(s, depth + 1)))
+  }
+  return depth
+}
+
+const depthLimitRule: ValidationRule = (context: ValidationContext) => ({
+  Document(doc) {
+    for (const def of doc.definitions) {
+      const depth = queryDepth(def as ASTNode)
+      if (depth > MAX_DEPTH) {
+        context.reportError(new GraphQLError(`Query depth limit exceeded (max: ${MAX_DEPTH}).`))
+      }
+    }
+  },
+})
+
+// ── Apollo Server ─────────────────────────────────────────────────────────────
+
+const server = new ApolloServer({ typeDefs, resolvers, validationRules: [depthLimitRule] })
 
 const handler = startServerAndCreateNextHandler<NextRequest>(server)
 

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -88,8 +88,9 @@ export const resolvers: Resolvers = {
   Query: {
     crashes: async (_, { filter, limit, offset }) => {
       const where = buildWhere(filter)
+      const cappedLimit = Math.min(limit ?? 1000, 5000)
       const [items, totalCount] = await Promise.all([
-        prisma.crashData.findMany({ where, skip: offset, take: limit }),
+        prisma.crashData.findMany({ where, skip: offset ?? 0, take: cappedLimit }),
         prisma.crashData.count({ where }),
       ])
       return { items, totalCount }


### PR DESCRIPTION
Add server-side GraphQL query depth limiting and pagination safeguards.

- Implement an inline ValidationRule in app/api/graphql/route.ts (MAX_DEPTH = 5) to reject queries that exceed allowed AST depth, using graphql's types and GraphQLError (no external dependency).
- Enforce pagination defaults and a hard cap in lib/graphql/resolvers.ts: offset defaults to 0 and limit is computed as Math.min(limit ?? 1000, 5000) to prevent unbounded queries.