### PR TITLE
Add Vitest test suites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,11 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - `lib/prisma.ts` — PrismaClient singleton (with `@prisma/adapter-pg`)
 - `lib/graphql/typeDefs.ts` — Full GraphQL schema (SDL string)
 - `lib/graphql/resolvers.ts` — All resolvers with severity bucket mapping and `buildWhere` helper
-- `app/api/graphql/route.ts` — Apollo Server route handler
+- `app/api/graphql/route.ts` — Apollo Server route handler; also contains the inline `depthLimitRule` validation rule (max depth: 5)
+- `lib/graphql/__generated__/types.ts` — Generated GraphQL types (committed; regenerated via `npm run codegen`)
+- `lib/graphql/__tests__/helpers.test.ts` — Unit tests for `rawToBucket`, `bucketsToRawValues`, `buildWhere`
+- `lib/graphql/__tests__/queries.test.ts` — Integration tests for all GraphQL queries via `executeOperation` with mocked Prisma
+- `vitest.config.ts` — Vitest configuration with `@` path alias
 - `lib/generated/prisma/` — Generated Prisma client (gitignored; regenerated via `postinstall: prisma generate`)
 
 ## What's Done
@@ -203,7 +207,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 **Deliverables:** Running Next.js app, populated database, Prisma client generated
 
-### Phase 2: API Layer (Week 1)
+### Phase 2: API Layer (Day 1)
 
 #### Milestone: Functional GraphQL API with core queries
 
@@ -216,12 +220,12 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Set up `graphql-codegen` for automatic TypeScript type generation
 - [x] Implement simple offset-based pagination
 - [x] Add query depth limiting for public API protection
-- [ ] Write integration tests for all resolvers
+- [x] Write integration tests for all resolvers
 - [ ] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build, `.next/cache` caching) with branch protection on `main`
 
 **Deliverables:** Fully tested GraphQL API accessible via Apollo Sandbox
 
-### Phase 3: Frontend Core (Weeks 2-3)
+### Phase 3: Frontend Core (Week 1)
 
 #### Milestone: Interactive map with filters
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.2.2
+**Version:** 0.2.3
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -133,6 +133,14 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Installed `@apollo/server`, `graphql`, and `@as-integrations/next`
 - Created `app/api/graphql/route.ts` with a stub hello-world schema using `startServerAndCreateNextHandler`
 - GraphQL endpoint accessible at `/api/graphql`; Apollo Sandbox Explorer available on GET
+
+### 2026-02-17 — Resolver Integration Tests
+
+- Installed Vitest (`vitest`) and created `vitest.config.ts` with `@` path alias matching tsconfig
+- Added `test` and `test:watch` scripts to `package.json`
+- Exported `SEVERITY_BUCKETS`, `rawToBucket`, `bucketsToRawValues`, `buildWhere` from `lib/graphql/resolvers.ts` for testability
+- Created `lib/graphql/__tests__/helpers.test.ts` — 37 unit tests for severity mapping and filter-to-where-clause logic
+- Created `lib/graphql/__tests__/queries.test.ts` — 19 integration tests using Apollo Server `executeOperation` with mocked Prisma (crashes, crash, crashStats, filterOptions queries + Crash field resolver edge cases)
 
 ### 2026-02-17 — Prisma Setup
 

--- a/lib/graphql/__tests__/helpers.test.ts
+++ b/lib/graphql/__tests__/helpers.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import { rawToBucket, bucketsToRawValues, buildWhere, SEVERITY_BUCKETS } from '../resolvers'
+
+// ── rawToBucket ─────────────────────────────────────────────────────────────
+
+describe('rawToBucket', () => {
+  // Death bucket
+  it('maps "Dead at Scene" to "Death"', () => {
+    expect(rawToBucket('Dead at Scene')).toBe('Death')
+  })
+  it('maps "Died in Hospital" to "Death"', () => {
+    expect(rawToBucket('Died in Hospital')).toBe('Death')
+  })
+  it('maps "Dead on Arrival" to "Death"', () => {
+    expect(rawToBucket('Dead on Arrival')).toBe('Death')
+  })
+
+  // Major Injury bucket
+  it('maps "Suspected Serious Injury" to "Major Injury"', () => {
+    expect(rawToBucket('Suspected Serious Injury')).toBe('Major Injury')
+  })
+
+  // Minor Injury bucket
+  it('maps "Suspected Minor Injury" to "Minor Injury"', () => {
+    expect(rawToBucket('Suspected Minor Injury')).toBe('Minor Injury')
+  })
+  it('maps "Possible Injury" to "Minor Injury"', () => {
+    expect(rawToBucket('Possible Injury')).toBe('Minor Injury')
+  })
+
+  // None bucket
+  it('maps "No Apparent Injury" to "None"', () => {
+    expect(rawToBucket('No Apparent Injury')).toBe('None')
+  })
+  it('maps "Unknown" to "None"', () => {
+    expect(rawToBucket('Unknown')).toBe('None')
+  })
+
+  // Edge cases
+  it('returns null for null input', () => {
+    expect(rawToBucket(null)).toBeNull()
+  })
+  it('returns null for undefined input', () => {
+    expect(rawToBucket(undefined)).toBeNull()
+  })
+  it('returns null for empty string', () => {
+    expect(rawToBucket('')).toBeNull()
+  })
+  it('passes through unmapped values as-is', () => {
+    expect(rawToBucket('Some Future Value')).toBe('Some Future Value')
+  })
+})
+
+// ── bucketsToRawValues ──────────────────────────────────────────────────────
+
+describe('bucketsToRawValues', () => {
+  it('expands "Death" to three raw values', () => {
+    expect(bucketsToRawValues(['Death'])).toEqual([
+      'Dead at Scene',
+      'Died in Hospital',
+      'Dead on Arrival',
+    ])
+  })
+
+  it('expands "Major Injury" to one raw value', () => {
+    expect(bucketsToRawValues(['Major Injury'])).toEqual(['Suspected Serious Injury'])
+  })
+
+  it('expands "Minor Injury" to two raw values', () => {
+    expect(bucketsToRawValues(['Minor Injury'])).toEqual([
+      'Suspected Minor Injury',
+      'Possible Injury',
+    ])
+  })
+
+  it('expands "None" to two raw values', () => {
+    expect(bucketsToRawValues(['None'])).toEqual(['No Apparent Injury', 'Unknown'])
+  })
+
+  it('expands multiple buckets into combined raw values', () => {
+    const result = bucketsToRawValues(['Death', 'Minor Injury'])
+    expect(result).toEqual([
+      'Dead at Scene',
+      'Died in Hospital',
+      'Dead on Arrival',
+      'Suspected Minor Injury',
+      'Possible Injury',
+    ])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(bucketsToRawValues([])).toEqual([])
+  })
+
+  it('passes through unknown bucket names as-is', () => {
+    expect(bucketsToRawValues(['SomeNewBucket'])).toEqual(['SomeNewBucket'])
+  })
+
+  it('filters out null and undefined elements', () => {
+    expect(bucketsToRawValues([null, undefined, 'Death'])).toEqual([
+      'Dead at Scene',
+      'Died in Hospital',
+      'Dead on Arrival',
+    ])
+  })
+})
+
+// ── buildWhere ──────────────────────────────────────────────────────────────
+
+describe('buildWhere', () => {
+  const NONE_RAW = SEVERITY_BUCKETS['None']
+
+  // buildWhere returns a spread object whose exact type is a union — cast to
+  // Record so we can assert on dynamic property names without TS errors.
+  const where = (filter?: Parameters<typeof buildWhere>[0]) =>
+    buildWhere(filter) as Record<string, unknown>
+
+  // Default None exclusion
+  it('excludes None severity by default (no filter)', () => {
+    expect(where()).toEqual({ mostSevereInjuryType: { notIn: NONE_RAW } })
+  })
+
+  it('excludes None severity when filter is empty object', () => {
+    expect(where({}).mostSevereInjuryType).toEqual({ notIn: NONE_RAW })
+  })
+
+  it('excludes None severity when filter is null', () => {
+    expect(where(null).mostSevereInjuryType).toEqual({ notIn: NONE_RAW })
+  })
+
+  // includeNoInjury
+  it('does not exclude None when includeNoInjury is true', () => {
+    expect(where({ includeNoInjury: true }).mostSevereInjuryType).toBeUndefined()
+  })
+
+  // Severity filter
+  it('expands severity buckets to raw values with in clause', () => {
+    expect(where({ severity: ['Death'] }).mostSevereInjuryType).toEqual({
+      in: ['Dead at Scene', 'Died in Hospital', 'Dead on Arrival'],
+    })
+  })
+
+  it('severity filter overrides default None exclusion', () => {
+    expect(where({ severity: ['None'] }).mostSevereInjuryType).toEqual({
+      in: ['No Apparent Injury', 'Unknown'],
+    })
+  })
+
+  // Simple field filters
+  it('adds mode filter', () => {
+    expect(where({ mode: 'Bicyclist', includeNoInjury: true }).mode).toBe('Bicyclist')
+  })
+
+  it('adds state filter', () => {
+    expect(where({ state: 'Ohio', includeNoInjury: true }).stateOrProvinceName).toBe('Ohio')
+  })
+
+  it('adds county filter', () => {
+    expect(where({ county: 'Franklin', includeNoInjury: true }).countyName).toBe('Franklin')
+  })
+
+  it('adds city filter', () => {
+    expect(where({ city: 'Columbus', includeNoInjury: true }).cityName).toBe('Columbus')
+  })
+
+  // Year filter
+  it('converts year to date range', () => {
+    expect(where({ year: 2024, includeNoInjury: true }).crashDate).toEqual({
+      gte: new Date('2024-01-01'),
+      lte: new Date('2024-12-31'),
+    })
+  })
+
+  // Date range filter
+  it('handles dateFrom only', () => {
+    expect(where({ dateFrom: '2024-06-01', includeNoInjury: true }).crashDate).toEqual({
+      gte: new Date('2024-06-01'),
+    })
+  })
+
+  it('handles dateTo only', () => {
+    expect(where({ dateTo: '2024-12-31', includeNoInjury: true }).crashDate).toEqual({
+      lte: new Date('2024-12-31'),
+    })
+  })
+
+  it('handles both dateFrom and dateTo', () => {
+    expect(
+      where({ dateFrom: '2024-01-01', dateTo: '2024-06-30', includeNoInjury: true }).crashDate
+    ).toEqual({
+      gte: new Date('2024-01-01'),
+      lte: new Date('2024-06-30'),
+    })
+  })
+
+  it('year takes precedence over dateFrom/dateTo', () => {
+    expect(
+      where({ year: 2023, dateFrom: '2024-01-01', dateTo: '2024-12-31', includeNoInjury: true })
+        .crashDate
+    ).toEqual({
+      gte: new Date('2023-01-01'),
+      lte: new Date('2023-12-31'),
+    })
+  })
+
+  // Bounding box
+  it('adds bbox filter', () => {
+    const w = where({
+      bbox: { minLat: 39.9, maxLat: 40.1, minLng: -83.1, maxLng: -82.9 },
+      includeNoInjury: true,
+    })
+    expect(w.latitude).toEqual({ gte: 39.9, lte: 40.1 })
+    expect(w.longitude).toEqual({ gte: -83.1, lte: -82.9 })
+  })
+
+  // Combined filters
+  it('combines multiple filters', () => {
+    const w = where({
+      mode: 'Pedestrian',
+      state: 'Ohio',
+      county: 'Franklin',
+      severity: ['Death', 'Major Injury'],
+      year: 2024,
+    })
+    expect(w.mode).toBe('Pedestrian')
+    expect(w.stateOrProvinceName).toBe('Ohio')
+    expect(w.countyName).toBe('Franklin')
+    expect(w.crashDate).toBeDefined()
+    expect(w.mostSevereInjuryType).toEqual({
+      in: ['Dead at Scene', 'Died in Hospital', 'Dead on Arrival', 'Suspected Serious Injury'],
+    })
+  })
+})

--- a/lib/graphql/__tests__/queries.test.ts
+++ b/lib/graphql/__tests__/queries.test.ts
@@ -1,0 +1,410 @@
+import { vi, describe, it, expect, beforeEach, assert } from 'vitest'
+import type { CrashData } from '@/lib/generated/prisma/client'
+
+// ── Mock Prisma ─────────────────────────────────────────────────────────────
+// vi.hoisted() returns values that are available inside vi.mock() factories,
+// which are hoisted to the top of the file before any other code runs.
+
+const mockPrisma = vi.hoisted(() => ({
+  crashData: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    count: vi.fn(),
+    groupBy: vi.fn(),
+  },
+  $queryRaw: vi.fn(),
+}))
+
+vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }))
+
+import { ApolloServer } from '@apollo/server'
+import { typeDefs } from '../typeDefs'
+import { resolvers } from '../resolvers'
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeCrashData(overrides: Partial<CrashData> = {}): CrashData {
+  return {
+    colliRptNum: 'RPT-001',
+    jurisdiction: 'Test PD',
+    stateOrProvinceName: 'Ohio',
+    regionName: 'Central',
+    countyName: 'Franklin',
+    cityName: 'Columbus',
+    fullDate: '2024-06-15T00:00:00',
+    fullTime: '14:30:00',
+    mostSevereInjuryType: 'Suspected Serious Injury',
+    ageGroup: '25-34',
+    involvedPersons: 2,
+    crashStatePlaneX: 1234.5,
+    crashStatePlaneY: 6789.0,
+    latitude: 39.9612,
+    longitude: -82.9988,
+    mode: 'Bicyclist',
+    crashDate: new Date('2024-06-15'),
+    geom: null,
+    ...overrides,
+  } as CrashData
+}
+
+let server: ApolloServer
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  server = new ApolloServer({ typeDefs, resolvers })
+})
+
+// ── crashes query ───────────────────────────────────────────────────────────
+
+describe('crashes query', () => {
+  const CRASHES_QUERY = `
+    query Crashes($filter: CrashFilter, $limit: Int, $offset: Int) {
+      crashes(filter: $filter, limit: $limit, offset: $offset) {
+        items {
+          colliRptNum
+          state
+          county
+          city
+          severity
+          mode
+          crashDate
+        }
+        totalCount
+      }
+    }
+  `
+
+  it('returns items and totalCount', async () => {
+    mockPrisma.crashData.findMany.mockResolvedValue([makeCrashData()])
+    mockPrisma.crashData.count.mockResolvedValue(1)
+
+    const result = await server.executeOperation({ query: CRASHES_QUERY })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.errors).toBeUndefined()
+    const data = result.body.singleResult.data?.crashes as {
+      items: Record<string, unknown>[]
+      totalCount: number
+    }
+    expect(data.totalCount).toBe(1)
+    expect(data.items).toHaveLength(1)
+    expect(data.items[0].colliRptNum).toBe('RPT-001')
+  })
+
+  it('maps Crash field resolvers correctly', async () => {
+    mockPrisma.crashData.findMany.mockResolvedValue([makeCrashData()])
+    mockPrisma.crashData.count.mockResolvedValue(1)
+
+    const result = await server.executeOperation({ query: CRASHES_QUERY })
+    assert(result.body.kind === 'single')
+    const item = (result.body.singleResult.data?.crashes as { items: Record<string, unknown>[] })
+      .items[0]
+
+    expect(item.state).toBe('Ohio')
+    expect(item.county).toBe('Franklin')
+    expect(item.city).toBe('Columbus')
+    expect(item.severity).toBe('Major Injury') // rawToBucket('Suspected Serious Injury')
+    expect(item.crashDate).toBe('2024-06-15')
+  })
+
+  it('caps limit at 5000', async () => {
+    mockPrisma.crashData.findMany.mockResolvedValue([])
+    mockPrisma.crashData.count.mockResolvedValue(0)
+
+    await server.executeOperation({
+      query: CRASHES_QUERY,
+      variables: { limit: 10000 },
+    })
+
+    expect(mockPrisma.crashData.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 5000 })
+    )
+  })
+
+  it('uses default limit of 1000', async () => {
+    mockPrisma.crashData.findMany.mockResolvedValue([])
+    mockPrisma.crashData.count.mockResolvedValue(0)
+
+    await server.executeOperation({ query: CRASHES_QUERY })
+
+    expect(mockPrisma.crashData.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 1000 })
+    )
+  })
+
+  it('passes offset to skip', async () => {
+    mockPrisma.crashData.findMany.mockResolvedValue([])
+    mockPrisma.crashData.count.mockResolvedValue(0)
+
+    await server.executeOperation({
+      query: CRASHES_QUERY,
+      variables: { offset: 50 },
+    })
+
+    expect(mockPrisma.crashData.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 50 })
+    )
+  })
+
+  it('passes severity filter to Prisma where clause', async () => {
+    mockPrisma.crashData.findMany.mockResolvedValue([])
+    mockPrisma.crashData.count.mockResolvedValue(0)
+
+    await server.executeOperation({
+      query: CRASHES_QUERY,
+      variables: { filter: { severity: ['Death'] } },
+    })
+
+    expect(mockPrisma.crashData.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          mostSevereInjuryType: {
+            in: ['Dead at Scene', 'Died in Hospital', 'Dead on Arrival'],
+          },
+        }),
+      })
+    )
+  })
+})
+
+// ── crash query ─────────────────────────────────────────────────────────────
+
+describe('crash query', () => {
+  const CRASH_QUERY = `
+    query Crash($colliRptNum: ID!) {
+      crash(colliRptNum: $colliRptNum) {
+        colliRptNum
+        severity
+        mode
+      }
+    }
+  `
+
+  it('returns a crash when found', async () => {
+    mockPrisma.crashData.findUnique.mockResolvedValue(makeCrashData())
+
+    const result = await server.executeOperation({
+      query: CRASH_QUERY,
+      variables: { colliRptNum: 'RPT-001' },
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.errors).toBeUndefined()
+    const crash = result.body.singleResult.data?.crash as Record<string, unknown>
+    expect(crash.colliRptNum).toBe('RPT-001')
+    expect(crash.severity).toBe('Major Injury')
+  })
+
+  it('returns null when not found', async () => {
+    mockPrisma.crashData.findUnique.mockResolvedValue(null)
+
+    const result = await server.executeOperation({
+      query: CRASH_QUERY,
+      variables: { colliRptNum: 'NONEXISTENT' },
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.data?.crash).toBeNull()
+  })
+})
+
+// ── crashStats query ────────────────────────────────────────────────────────
+
+describe('crashStats query', () => {
+  const STATS_QUERY = `
+    query CrashStats($filter: CrashFilter) {
+      crashStats(filter: $filter) {
+        totalCrashes
+        totalFatal
+        byMode { mode count }
+        bySeverity { severity count }
+        byCounty { county count }
+      }
+    }
+  `
+
+  it('returns aggregated stats', async () => {
+    mockPrisma.crashData.count.mockResolvedValueOnce(100).mockResolvedValueOnce(5)
+    mockPrisma.crashData.groupBy
+      .mockResolvedValueOnce([
+        { mode: 'Bicyclist', _count: { _all: 60 } },
+        { mode: 'Pedestrian', _count: { _all: 40 } },
+      ])
+      .mockResolvedValueOnce([
+        { mostSevereInjuryType: 'Dead at Scene', _count: { _all: 3 } },
+        { mostSevereInjuryType: 'Suspected Serious Injury', _count: { _all: 20 } },
+      ])
+      .mockResolvedValueOnce([
+        { countyName: 'Franklin', _count: { _all: 50 } },
+        { countyName: 'Hamilton', _count: { _all: 30 } },
+      ])
+
+    const result = await server.executeOperation({ query: STATS_QUERY })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.errors).toBeUndefined()
+    const stats = result.body.singleResult.data?.crashStats as Record<string, unknown>
+
+    expect(stats.totalCrashes).toBe(100)
+    expect(stats.totalFatal).toBe(5)
+    expect(stats.byMode).toHaveLength(2)
+    expect(stats.bySeverity).toContainEqual({ severity: 'Death', count: 3 })
+    expect(stats.bySeverity).toContainEqual({ severity: 'Major Injury', count: 20 })
+    expect(stats.byCounty).toHaveLength(2)
+  })
+
+  it('merges multiple raw severity values into same bucket', async () => {
+    mockPrisma.crashData.count.mockResolvedValueOnce(25).mockResolvedValueOnce(10)
+    mockPrisma.crashData.groupBy
+      .mockResolvedValueOnce([]) // byMode
+      .mockResolvedValueOnce([
+        { mostSevereInjuryType: 'Dead at Scene', _count: { _all: 7 } },
+        { mostSevereInjuryType: 'Dead on Arrival', _count: { _all: 3 } },
+        { mostSevereInjuryType: 'Suspected Minor Injury', _count: { _all: 15 } },
+        { mostSevereInjuryType: 'Possible Injury', _count: { _all: 10 } },
+      ])
+      .mockResolvedValueOnce([]) // byCounty
+
+    const result = await server.executeOperation({ query: STATS_QUERY })
+    assert(result.body.kind === 'single')
+    const bySeverity = (result.body.singleResult.data?.crashStats as { bySeverity: unknown[] })
+      .bySeverity
+
+    expect(bySeverity).toContainEqual({ severity: 'Death', count: 10 })
+    expect(bySeverity).toContainEqual({ severity: 'Minor Injury', count: 25 })
+  })
+})
+
+// ── filterOptions query ─────────────────────────────────────────────────────
+
+describe('filterOptions query', () => {
+  it('returns states from raw SQL', async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ state: 'Ohio' }, { state: 'Indiana' }])
+
+    const result = await server.executeOperation({
+      query: `{ filterOptions { states } }`,
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.data?.filterOptions).toEqual({ states: ['Ohio', 'Indiana'] })
+  })
+
+  it('returns counties filtered by state', async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ county: 'Franklin' }, { county: 'Hamilton' }])
+
+    const result = await server.executeOperation({
+      query: `{ filterOptions { counties(state: "Ohio") } }`,
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.data?.filterOptions).toEqual({
+      counties: ['Franklin', 'Hamilton'],
+    })
+  })
+
+  it('returns cities filtered by state and county', async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ city: 'Columbus' }, { city: 'Dublin' }])
+
+    const result = await server.executeOperation({
+      query: `{ filterOptions { cities(state: "Ohio", county: "Franklin") } }`,
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.data?.filterOptions).toEqual({
+      cities: ['Columbus', 'Dublin'],
+    })
+  })
+
+  it('returns years from raw SQL', async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ year: 2024 }, { year: 2023 }, { year: 2022 }])
+
+    const result = await server.executeOperation({
+      query: `{ filterOptions { years } }`,
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.data?.filterOptions).toEqual({ years: [2024, 2023, 2022] })
+  })
+
+  it('returns hardcoded severities', async () => {
+    const result = await server.executeOperation({
+      query: `{ filterOptions { severities } }`,
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.data?.filterOptions).toEqual({
+      severities: ['Death', 'Major Injury', 'Minor Injury', 'None'],
+    })
+  })
+
+  it('returns hardcoded modes', async () => {
+    const result = await server.executeOperation({
+      query: `{ filterOptions { modes } }`,
+    })
+
+    assert(result.body.kind === 'single')
+    expect(result.body.singleResult.data?.filterOptions).toEqual({
+      modes: ['Bicyclist', 'Pedestrian'],
+    })
+  })
+})
+
+// ── Crash field resolver edge cases ─────────────────────────────────────────
+
+describe('Crash field resolvers', () => {
+  const CRASH_DETAIL_QUERY = `
+    query Crash($id: ID!) {
+      crash(colliRptNum: $id) {
+        severity
+        crashDate
+        state
+        region
+        county
+        city
+        date
+        time
+      }
+    }
+  `
+
+  it('severity returns null for null mostSevereInjuryType', async () => {
+    mockPrisma.crashData.findUnique.mockResolvedValue(makeCrashData({ mostSevereInjuryType: null }))
+
+    const result = await server.executeOperation({
+      query: CRASH_DETAIL_QUERY,
+      variables: { id: 'RPT-001' },
+    })
+
+    assert(result.body.kind === 'single')
+    const crash = result.body.singleResult.data?.crash as Record<string, unknown>
+    expect(crash.severity).toBeNull()
+  })
+
+  it('crashDate returns null when crashDate is null', async () => {
+    mockPrisma.crashData.findUnique.mockResolvedValue(makeCrashData({ crashDate: null }))
+
+    const result = await server.executeOperation({
+      query: CRASH_DETAIL_QUERY,
+      variables: { id: 'RPT-001' },
+    })
+
+    assert(result.body.kind === 'single')
+    const crash = result.body.singleResult.data?.crash as Record<string, unknown>
+    expect(crash.crashDate).toBeNull()
+  })
+
+  it('severity passes through unmapped raw values', async () => {
+    mockPrisma.crashData.findUnique.mockResolvedValue(
+      makeCrashData({ mostSevereInjuryType: 'Some Future Value' })
+    )
+
+    const result = await server.executeOperation({
+      query: CRASH_DETAIL_QUERY,
+      variables: { id: 'RPT-001' },
+    })
+
+    assert(result.body.kind === 'single')
+    const crash = result.body.singleResult.data?.crash as Record<string, unknown>
+    expect(crash.severity).toBe('Some Future Value')
+  })
+})

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -7,7 +7,7 @@ import type { CrashFilter, Resolvers } from './__generated__/types'
 // New raw values from future data imports will fall through to rawToBucket's
 // passthrough return, so they render as-is rather than silently disappearing.
 
-const SEVERITY_BUCKETS: Record<string, string[]> = {
+export const SEVERITY_BUCKETS: Record<string, string[]> = {
   Death: ['Dead at Scene', 'Died in Hospital', 'Dead on Arrival'],
   'Major Injury': ['Suspected Serious Injury'],
   'Minor Injury': ['Suspected Minor Injury', 'Possible Injury'],
@@ -16,7 +16,7 @@ const SEVERITY_BUCKETS: Record<string, string[]> = {
 
 const NONE_VALUES = SEVERITY_BUCKETS['None']
 
-function rawToBucket(raw: string | null | undefined): string | null {
+export function rawToBucket(raw: string | null | undefined): string | null {
   if (!raw) return null
   for (const [bucket, values] of Object.entries(SEVERITY_BUCKETS)) {
     if (values.includes(raw)) return bucket
@@ -27,13 +27,13 @@ function rawToBucket(raw: string | null | undefined): string | null {
 // Expand display bucket names to the raw DB values they represent.
 // Accepts nullable elements because the generated CrashFilter.severity type is
 // Array<string | null | undefined> (GraphQL [String] allows null list items).
-function bucketsToRawValues(buckets: ReadonlyArray<string | null | undefined>): string[] {
+export function bucketsToRawValues(buckets: ReadonlyArray<string | null | undefined>): string[] {
   return buckets.flatMap((b) => (b ? (SEVERITY_BUCKETS[b] ?? [b]) : []))
 }
 
 // ── Build Prisma where clause from GraphQL filter input ───────────────────────
 
-function buildWhere(filter?: CrashFilter | null) {
+export function buildWhere(filter?: CrashFilter | null) {
   const { severity, mode, state, county, city, dateFrom, dateTo, year, bbox, includeNoInjury } =
     filter ?? {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "shadcn": "^3.8.5",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1194,6 +1195,448 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5530,6 +5973,356 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -5957,6 +6750,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -6590,6 +7401,117 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@whatwg-node/disposablestack": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
@@ -7013,6 +7935,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -7392,6 +8324,16 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -8550,6 +9492,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -8607,6 +9556,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -9088,6 +10079,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9163,6 +10164,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -9572,6 +10583,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -12815,6 +13841,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -14129,6 +15166,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -14705,6 +15787,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -14851,6 +15940,13 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -15264,6 +16360,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -15320,6 +16423,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/title-case": {
@@ -15966,6 +17079,203 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -16105,6 +17415,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "codegen": "graphql-codegen --config codegen.ts",
     "postinstall": "prisma generate",
     "prepare": "husky"
@@ -58,6 +60,7 @@
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})


### PR DESCRIPTION
Add comprehensive Vitest test suites for both helper logic and GraphQL queries/resolvers. Adds vitest.config.ts and updates package.json/package-lock to include Vitest and test-related deps. Tests cover severity bucket mapping/expansion, Prisma where-clause construction, crashes/crashStats/filterOptions queries, and Crash field resolver edge cases using a mocked Prisma client.