### PR TITLE
Add test step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Test
+        run: npm run test
+
       - name: Build
         run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 ### Phase 1: Foundation (Day 1)
 
-#### Milestone: Project scaffolding and data model\*\*
+#### Milestone: Project scaffolding and data model
 
 - [x] Purchase domain: **crashmap.io** ✓
 - [x] Initialize Next.js project with TypeScript (`create-next-app --typescript`)
@@ -221,7 +221,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Implement simple offset-based pagination
 - [x] Add query depth limiting for public API protection
 - [x] Write integration tests for all resolvers
-- [ ] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build, `.next/cache` caching) with branch protection on `main`
+- [x] Set up GitHub Actions CI pipeline (lint, format check, typecheck, build, `.next/cache` caching) with branch protection on `main`
 
 **Deliverables:** Fully tested GraphQL API accessible via Apollo Sandbox
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.2.3
+**Version:** 0.3.0
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -63,6 +63,8 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Created `.github/workflows/ci.yml` with lint, format check, typecheck, and build steps
 - Added `typecheck` script (`tsc --noEmit`) to `package.json`
 - Added `.next/cache` caching to CI workflow to eliminate Next.js build cache warning and speed up repeat builds
+- Added Vitest test step to CI workflow (runs all unit and integration tests before build)
+- Configured `main` branch protection: require CI to pass before merging
 
 ### 2026-02-17 — Linting & Formatting
 


### PR DESCRIPTION
Insert a Test step into .github/workflows/ci.yml that runs `npm run test` (placed between type checking and build). Ensures the project's test suite runs in CI before the build step.