### PR TITLE
Add Apollo Client integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -730,6 +730,12 @@ You're on Render's **Professional plan** (web services) with the **Basic Postgre
 | **Build times**                  | Next.js + Prisma generate + codegen can be slow.                                                                                                                                                      | Cache `node_modules` and Prisma client in Render's build settings. Use `npm ci` instead of `npm install`.                                  |
 | **No built-in analytics**        | Render doesn't include web analytics like Vercel Analytics.                                                                                                                                           | Add Plausible, Fathom, or a self-hosted analytics solution. Or just rely on Lighthouse CI in your CI/CD pipeline for performance tracking. |
 
+### Smoke-Test Deployment
+
+**Deploy early — before frontend work begins.** Before building the map and filters, do a smoke-test deploy: create `render.yaml`, set `DATABASE_URL` in the Render dashboard (remove it from the tracked `.env` file), push to `main`, and verify the GraphQL endpoint responds at `https://<app>.onrender.com/api/graphql`. Catching deployment blockers (Prisma adapter issues, missing env vars, build failures) before Phase 3 is complete saves significant rework.
+
+Set `output: 'standalone'` in `next.config.ts` for optimal builds on Render (already called out in the issues table above).
+
 ### Testing Challenges
 
 | Challenge                          | Mitigation                                                                                                                                                             |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,16 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 #### Milestone: Interactive map with filters
 
-- [ ] Set up Apollo Client with InMemoryCache and type policies
+- [x] Set up Apollo Client with InMemoryCache and type policies
+- [ ] **Smoke-test deployment to Render** (verify production build before frontend work begins):
+  - Create `render.yaml` at project root specifying build command (`npm ci && npm run build`), start command (`npm start`), Node 20, and env var declarations
+  - Create `.env.example` documenting all required env vars (`DATABASE_URL`, `NEXT_PUBLIC_MAPBOX_TOKEN`) so Render dashboard setup is clear
+  - Remove plaintext `DATABASE_URL` from tracked `.env` file (rotate credentials on Render if needed); set only in Render dashboard as an environment variable
+  - Create Render web service via dashboard: link to GitHub repo `main` branch, set `DATABASE_URL` env var, enable auto-deploy on push
+  - Set `output: 'standalone'` in `next.config.ts` for optimal builds on Render
+  - Verify `npm run build && npm start` passes locally against production database (confirms Prisma 7 adapter-pg and Apollo Server work outside dev mode)
+  - Push to `main`, confirm CI passes, confirm Render auto-deploy succeeds
+  - Hit `/api/graphql` on the Render-assigned `.onrender.com` URL to verify the GraphQL endpoint responds (no frontend needed yet)
 - [ ] Install shadcn/ui components needed for the UI:
   - `npx shadcn-ui@latest add button select checkbox toggle-group sheet dialog badge popover calendar`
 - [ ] Build interactive map component with Mapbox GL JS (`react-map-gl`):

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.3.0
+**Version:** 0.3.1
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,14 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-17 — Apollo Client Setup (Phase 3 Start)
+
+- Installed `@apollo/client` and `@apollo/client-integration-nextjs` (the current successor to the deprecated `@apollo/experimental-nextjs-app-support`)
+- Created `lib/apollo-client.ts` — RSC client via `registerApolloClient` (use `getClient()` in Server Components)
+- Created `app/apollo-provider.tsx` — `"use client"` wrapper with `ApolloNextAppProvider` for Client Components
+- Updated `app/layout.tsx` to wrap children in `<ApolloProvider>`
+- Configured `InMemoryCache` type policies: `Crash` → `keyFields: ["colliRptNum"]`; all aggregate/wrapper types → `keyFields: false`
 
 ### 2026-02-17 — Initial Config & Database Setup
 

--- a/app/apollo-provider.tsx
+++ b/app/apollo-provider.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { HttpLink } from '@apollo/client'
+import {
+  ApolloClient,
+  ApolloNextAppProvider,
+  InMemoryCache,
+} from '@apollo/client-integration-nextjs'
+
+function makeClient() {
+  const httpLink = new HttpLink({ uri: '/api/graphql' })
+
+  return new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Crash: { keyFields: ['colliRptNum'] },
+        CrashResult: { keyFields: false },
+        CrashStats: { keyFields: false },
+        FilterOptions: { keyFields: false },
+        ModeStat: { keyFields: false },
+        SeverityStat: { keyFields: false },
+        CountyStat: { keyFields: false },
+      },
+    }),
+    link: httpLink,
+  })
+}
+
+export function ApolloProvider({ children }: React.PropsWithChildren) {
+  return <ApolloNextAppProvider makeClient={makeClient}>{children}</ApolloNextAppProvider>
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import { ApolloProvider } from './apollo-provider'
 import './globals.css'
 
 const geistSans = Geist({
@@ -24,7 +25,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ApolloProvider>{children}</ApolloProvider>
+      </body>
     </html>
   )
 }

--- a/lib/apollo-client.ts
+++ b/lib/apollo-client.ts
@@ -1,0 +1,35 @@
+import { HttpLink } from '@apollo/client'
+import {
+  ApolloClient,
+  InMemoryCache,
+  registerApolloClient,
+} from '@apollo/client-integration-nextjs'
+
+function makeCache() {
+  return new InMemoryCache({
+    typePolicies: {
+      // Crash has a natural ID: colliRptNum (Apollo defaults to "id" or "_id")
+      Crash: {
+        keyFields: ['colliRptNum'],
+      },
+      // Wrapper and aggregate types have no natural ID — skip normalization
+      CrashResult: { keyFields: false },
+      CrashStats: { keyFields: false },
+      FilterOptions: { keyFields: false },
+      ModeStat: { keyFields: false },
+      SeverityStat: { keyFields: false },
+      CountyStat: { keyFields: false },
+    },
+  })
+}
+
+// RSC / Server Component client
+// NEXT_PUBLIC_APP_URL must be set in production (e.g. https://crashmap.onrender.com)
+export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
+  return new ApolloClient({
+    cache: makeCache(),
+    link: new HttpLink({
+      uri: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}/api/graphql`,
+    }),
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@apollo/client": "^4.1.4",
+        "@apollo/client-integration-nextjs": "^0.14.4",
         "@apollo/server": "^5.4.0",
         "@as-integrations/next": "^4.1.0",
         "@prisma/adapter-pg": "^7.4.0",
@@ -89,6 +91,80 @@
       "license": "MIT",
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.1.4.tgz",
+      "integrity": "sha512-bTbxPHGXDMcYyQuWcYOzvWBHHJ+5ehvH3uKhd3+jI8X3ZPgWlfiI0MYN3r2exq/SNo5/TbL1p+bzQnE1xf+5tg==",
+      "license": "MIT",
+      "workspaces": [
+        "dist",
+        "codegen",
+        "scripts/codemods/ac3-to-ac4"
+      ],
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/client-integration-nextjs": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client-integration-nextjs/-/client-integration-nextjs-0.14.4.tgz",
+      "integrity": "sha512-4fXHqP3Nh87PvJ3lOU7i/phFPrcfuhla4lWF0H9zyIm1TJGRMZRfJ/27SU87pb/f0rzGKKPzKH+N8dmKOqY3qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/client-react-streaming": "0.14.4"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^4.0.0",
+        "next": "^15.2.3 || ^16.0.0",
+        "react": "^19",
+        "rxjs": "^7.3.0"
+      }
+    },
+    "node_modules/@apollo/client-integration-nextjs/node_modules/@apollo/client-react-streaming": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client-react-streaming/-/client-react-streaming-0.14.4.tgz",
+      "integrity": "sha512-4f2aZHLfNBWcBGJYWSVQRJVVJ76qW1cLhDcM6YAKey9At86sHt6QfIkAmmHT0yxgwjPCWQiTIQOPwPcwjSswIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-dom": "^19.0.0",
+        "@wry/equality": "^0.5.6"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^4.0.0",
+        "graphql": "^16 || >=17.0.0-alpha.2",
+        "react": "^19",
+        "react-dom": "^19",
+        "rxjs": "^7.3.0"
       }
     },
     "node_modules/@apollo/protobufjs": {
@@ -6810,7 +6886,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6820,7 +6895,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -7566,6 +7640,54 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/accepts": {
@@ -8878,7 +9000,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -11248,7 +11369,6 @@
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -11264,7 +11384,7 @@
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.7.tgz",
       "integrity": "sha512-yoLRW+KRlDmnnROdAu7sX77VNLC0bsFoZyGQJLy1cF+X/SkLg/fWkRGrEEYQK8o2cafJ2wmEaMqMEZB3U3DYDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -13918,6 +14038,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -15274,6 +15406,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -17515,7 +17657,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     ]
   },
   "dependencies": {
+    "@apollo/client": "^4.1.4",
+    "@apollo/client-integration-nextjs": "^0.14.4",
     "@apollo/server": "^5.4.0",
     "@as-integrations/next": "^4.1.0",
     "@prisma/adapter-pg": "^7.4.0",


### PR DESCRIPTION
Add Apollo integration for both client and server components. Introduces app/apollo-provider.tsx (client-side ApolloNextAppProvider) and lib/apollo-client.ts (registers server/RSC client exposing getClient/query/PreloadQuery). Both use an InMemoryCache with typePolicies (Crash keyed by colliRptNum; several wrapper/aggregate types disabled for normalization). Wrap RootLayout with the ApolloProvider and add @apollo/client and @apollo/client-integration-nextjs to package.json.