### PR TITLE
Add Render deployment config and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# PostgreSQL connection string — set in Render dashboard, never commit the real value
+DATABASE_URL="postgresql://user:password@host/database"
+
+# Mapbox public access token — get from mapbox.com/account/access-tokens
+NEXT_PUBLIC_MAPBOX_TOKEN="pk.eyJ1IjoiLi4uIn0..."
+
+# Absolute base URL of the deployed app — used by Apollo Client for SSR
+# Local dev: http://localhost:3000
+# Production: https://crashmap.io (or your .onrender.com URL until the domain is wired up)
+NEXT_PUBLIC_APP_URL="https://crashmap.io"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [ ] Set up CI/CD pipeline (GitHub Actions):
   - Lint → Type check → Test → Codegen → Build → Deploy
 - [ ] Configure basic monitoring (Sentry for errors, Lighthouse CI for web vitals)
+- [ ] Add a health check endpoint (e.g. `GET /api/health` returning `200 OK`) and set **Health Check Path** to `/api/health` in Render web service settings → Health & Alerts
 
 **Deliverables:** Deployed, public-facing production application
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.3.1
+**Version:** 0.3.2
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -151,6 +151,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Exported `SEVERITY_BUCKETS`, `rawToBucket`, `bucketsToRawValues`, `buildWhere` from `lib/graphql/resolvers.ts` for testability
 - Created `lib/graphql/__tests__/helpers.test.ts` — 37 unit tests for severity mapping and filter-to-where-clause logic
 - Created `lib/graphql/__tests__/queries.test.ts` — 19 integration tests using Apollo Server `executeOperation` with mocked Prisma (crashes, crash, crashStats, filterOptions queries + Crash field resolver edge cases)
+
+### 2026-02-17 — Render Deployment Setup
+
+- Added `render.yaml` declaring web service build/start commands, Node 20, and env var declarations (`DATABASE_URL`, `NEXT_PUBLIC_MAPBOX_TOKEN`, `NEXT_PUBLIC_APP_URL`)
+- Created `.env.example` documenting all required env vars with placeholder values
+- Set `output: 'standalone'` in `next.config.ts` for optimized Render deploys (start command: `node .next/standalone/server.js`)
+- Confirmed production build passes locally (`npm run build` compiles clean; Windows-only EINVAL warning on bracket filenames is harmless on Render's Linux)
 
 ### 2026-02-17 — Prisma Setup
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'standalone',
 }
 
 export default nextConfig

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: crashmap
+    runtime: node
+    buildCommand: >-
+      npm ci && npm run build &&
+      cp -r public .next/standalone/public &&
+      cp -r .next/static .next/standalone/.next/static
+    startCommand: node .next/standalone/server.js
+    nodeVersion: 20
+    envVars:
+      - key: DATABASE_URL
+        sync: false
+      - key: NEXT_PUBLIC_MAPBOX_TOKEN
+        sync: false
+      - key: NEXT_PUBLIC_APP_URL
+        sync: false


### PR DESCRIPTION
Enable Next.js standalone output and add Render deployment manifests and environment examples. Updates next.config.ts to use output: 'standalone' for building a self-contained server bundle. Adds render.yaml to define a Render web service (build/start commands, Node 20, and required env vars). Adds .env.example documenting DATABASE_URL, NEXT_PUBLIC_MAPBOX_TOKEN, and NEXT_PUBLIC_APP_URL for local/dev configuration and guidance.