### PR TITLE
Mapbox Token Configured

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
   - Add `transpilePackages: ['react-map-gl', 'mapbox-gl']` to `next.config.ts` (ESM/App Router compat)
   - Import `mapbox-gl/dist/mapbox-gl.css` in `app/layout.tsx` (required for popups, markers, controls)
   - `NEXT_PUBLIC_MAPBOX_TOKEN` must be set in `.env.local` (already in `.env.example`)
-- [ ] Secure Mapbox access token via environment variable (`NEXT_PUBLIC_MAPBOX_TOKEN`)
+- [x] Secure Mapbox access token via environment variable (`NEXT_PUBLIC_MAPBOX_TOKEN`)
 - [ ] Replace `app/page.tsx` with a full-viewport root layout container (`100dvh`, relative positioning)
   - Strip all Next.js boilerplate; render `<MapContainer />` inside `<div style={{ position: 'relative', width: '100%', height: '100dvh' }}>`
   - `position: relative` is the anchor for future absolutely-positioned overlays

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Created `lib/graphql/__tests__/helpers.test.ts` — 37 unit tests for severity mapping and filter-to-where-clause logic
 - Created `lib/graphql/__tests__/queries.test.ts` — 19 integration tests using Apollo Server `executeOperation` with mocked Prisma (crashes, crash, crashStats, filterOptions queries + Crash field resolver edge cases)
 
+### 2026-02-18 — Mapbox Token Configured
+
+- Added `NEXT_PUBLIC_MAPBOX_TOKEN` to `.env.local` for local development (gitignored)
+- Set `NEXT_PUBLIC_MAPBOX_TOKEN` in Render dashboard for production (already declared in `render.yaml` with `sync: false`)
+- Applied URL restrictions to the Mapbox public token (localhost, Render URL, crashmap.io)
+
 ### 2026-02-18 — Map Dependencies Installed
 
 - Installed `react-map-gl@8.1.0`, `mapbox-gl@3.18.1`, `@types/mapbox-gl@3.4.1`


### PR DESCRIPTION
- Added `NEXT_PUBLIC_MAPBOX_TOKEN` to `.env.local` for local development (gitignored)
- Set `NEXT_PUBLIC_MAPBOX_TOKEN` in Render dashboard for production (already declared in `render.yaml` with `sync: false`)
- Applied URL restrictions to the Mapbox public token (localhost, Render URL, crashmap.io)

Closes #57 