### PR TITLE
Map Page Built

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,11 +244,12 @@ Severity-based visual hierarchy using color, opacity, AND size:
   - Import `mapbox-gl/dist/mapbox-gl.css` in `app/layout.tsx` (required for popups, markers, controls)
   - `NEXT_PUBLIC_MAPBOX_TOKEN` must be set in `.env.local` (already in `.env.example`)
 - [x] Secure Mapbox access token via environment variable (`NEXT_PUBLIC_MAPBOX_TOKEN`)
-- [ ] Replace `app/page.tsx` with a full-viewport root layout container (`100dvh`, relative positioning)
+- [x] Replace `app/page.tsx` with a full-viewport root layout container (`100dvh`, relative positioning)
   - Strip all Next.js boilerplate; render `<MapContainer />` inside `<div style={{ position: 'relative', width: '100%', height: '100dvh' }}>`
   - `position: relative` is the anchor for future absolutely-positioned overlays
   - `page.tsx` stays a Server Component; client code is isolated in `MapContainer`
-- [ ] Build `MapContainer` component: `react-map-gl` map filling 100% of its container, Mapbox token from env var, no data layers yet
+  - Added `devIndicators: false` to `next.config.ts` to suppress the Next.js dev-mode badge
+- [x] Build `MapContainer` component: `react-map-gl` map filling 100% of its container, Mapbox token from env var, no data layers yet
   - File: `components/map/MapContainer.tsx` — `'use client'` (Mapbox has no SSR support)
   - Import `Map` from `react-map-gl/mapbox` (required for mapbox-gl >= 3.5)
   - `mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.3.3
+**Version:** 0.3.4
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -151,6 +151,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Exported `SEVERITY_BUCKETS`, `rawToBucket`, `bucketsToRawValues`, `buildWhere` from `lib/graphql/resolvers.ts` for testability
 - Created `lib/graphql/__tests__/helpers.test.ts` — 37 unit tests for severity mapping and filter-to-where-clause logic
 - Created `lib/graphql/__tests__/queries.test.ts` — 19 integration tests using Apollo Server `executeOperation` with mocked Prisma (crashes, crash, crashStats, filterOptions queries + Crash field resolver edge cases)
+
+### 2026-02-18 — Map Page Built
+
+- Created `components/map/MapContainer.tsx` — `'use client'` component with `react-map-gl/mapbox`, centered on Washington state, `light-v11` basemap
+- Replaced `app/page.tsx` boilerplate with a full-viewport layout (`100dvh`, `position: relative` for future overlays)
+- Added `devIndicators: false` to `next.config.ts` to suppress the Next.js dev-mode badge overlapping the map
 
 ### 2026-02-18 — Mapbox Token Configured
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,65 +1,9 @@
-import Image from 'next/image'
+import { MapContainer } from '@/components/map/MapContainer'
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{' '}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{' '}
-            or the{' '}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{' '}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+    <div style={{ position: 'relative', width: '100%', height: '100dvh' }}>
+      <MapContainer />
     </div>
   )
 }

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import Map from 'react-map-gl/mapbox'
+
+export function MapContainer() {
+  return (
+    <Map
+      mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+      initialViewState={{ longitude: -120.5, latitude: 47.5, zoom: 7 }}
+      style={{ width: '100%', height: '100%' }}
+      mapStyle="mapbox://styles/mapbox/light-v11"
+    />
+  )
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   output: 'standalone',
   transpilePackages: ['react-map-gl', 'mapbox-gl'],
+  devIndicators: false,
 }
 
 export default nextConfig


### PR DESCRIPTION
- Created `components/map/MapContainer.tsx` — `'use client'` component with `react-map-gl/mapbox`, centered on Washington state, `light-v11` basemap
- Replaced `app/page.tsx` boilerplate with a full-viewport layout (`100dvh`, `position: relative` for future overlays)
- Added `devIndicators: false` to `next.config.ts` to suppress the Next.js dev-mode badge overlapping the map

Closes #28