### PR TITLE
Desktop Sidebar Scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,11 +256,12 @@ Severity-based visual hierarchy using color, opacity, AND size:
   - `initialViewState`: longitude -120.5, latitude 47.5, zoom 7 (Washington state)
   - `mapStyle="mapbox://styles/mapbox/light-v11"` — clean light basemap for data visualization
   - `style={{ width: '100%', height: '100%' }}` — fills parent; parent owns `100dvh`
-- [ ] Build desktop `Sidebar` component: fixed right panel (~320px) using shadcn/ui `Sheet`, toggled by a header button, hidden on mobile
+- [x] Build desktop `Sidebar` component: fixed right panel (~320px) using shadcn/ui `Sheet`, toggled by a header button, hidden on mobile
 - [ ] Build mobile `FilterOverlay` component: full-screen overlay with open/close toggle button, visible only on mobile (<768px)
 - [ ] Build `SummaryBar` component: persistent bar with placeholder crash count and empty filter badge area, visible on all screen sizes
 - [ ] Wire `map.resize()` to sidebar and overlay open/close transitions
 - [ ] Smoke test responsive layout at mobile (<768px) and desktop (≥768px) breakpoints
+- [ ] Import Domain into Render settings
 
 #### Milestone: Interactive map with filters
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.3.4
+**Version:** 0.3.5
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -151,6 +151,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Exported `SEVERITY_BUCKETS`, `rawToBucket`, `bucketsToRawValues`, `buildWhere` from `lib/graphql/resolvers.ts` for testability
 - Created `lib/graphql/__tests__/helpers.test.ts` — 37 unit tests for severity mapping and filter-to-where-clause logic
 - Created `lib/graphql/__tests__/queries.test.ts` — 19 integration tests using Apollo Server `executeOperation` with mocked Prisma (crashes, crash, crashStats, filterOptions queries + Crash field resolver edge cases)
+
+### 2026-02-18 — Desktop Sidebar Scaffold
+
+- Created `components/sidebar/Sidebar.tsx` — Sheet-based right panel (320px), desktop-only overlay with "Filters" header and placeholder content
+- Created `components/layout/AppShell.tsx` — `'use client'` wrapper managing sidebar open/close state; renders `MapContainer`, a floating `SlidersHorizontal` toggle button (hidden on mobile via `hidden md:block`), and `Sidebar`
+- Updated `app/page.tsx` to render `AppShell` instead of `MapContainer` directly; page stays a Server Component
 
 ### 2026-02-18 — Map Page Built
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
-import { MapContainer } from '@/components/map/MapContainer'
+import { AppShell } from '@/components/layout/AppShell'
 
 export default function Home() {
   return (
     <div style={{ position: 'relative', width: '100%', height: '100dvh' }}>
-      <MapContainer />
+      <AppShell />
     </div>
   )
 }

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState } from 'react'
+import { SlidersHorizontal } from 'lucide-react'
+import { MapContainer } from '@/components/map/MapContainer'
+import { Sidebar } from '@/components/sidebar/Sidebar'
+import { Button } from '@/components/ui/button'
+
+export function AppShell() {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  return (
+    <>
+      <MapContainer />
+
+      {/* Sidebar toggle button — desktop only */}
+      <div className="absolute top-4 right-4 z-10 hidden md:block">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setSidebarOpen(true)}
+          aria-label="Open filters"
+        >
+          <SlidersHorizontal className="size-4" />
+        </Button>
+      </div>
+
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+    </>
+  )
+}

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,0 +1,21 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+
+interface SidebarProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function Sidebar({ isOpen, onClose }: SidebarProps) {
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="w-80 sm:max-w-80">
+        <SheetHeader>
+          <SheetTitle>Filters</SheetTitle>
+        </SheetHeader>
+        <div className="px-4 pb-4">
+          <p className="text-sm text-muted-foreground">Filter controls coming soon.</p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}


### PR DESCRIPTION
- Created `components/sidebar/Sidebar.tsx` — Sheet-based right panel (320px), desktop-only overlay with "Filters" header and placeholder content
- Created `components/layout/AppShell.tsx` — `'use client'` wrapper managing sidebar open/close state; renders `MapContainer`, a floating `SlidersHorizontal` toggle button (hidden on mobile via `hidden md:block`), and `Sidebar`
- Updated `app/page.tsx` to render `AppShell` instead of `MapContainer` directly; page stays a Server Component

Closes #29