### PR TITLE
Add Mobile Filter Overlay Scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
   - `mapStyle="mapbox://styles/mapbox/light-v11"` — clean light basemap for data visualization
   - `style={{ width: '100%', height: '100%' }}` — fills parent; parent owns `100dvh`
 - [x] Build desktop `Sidebar` component: fixed right panel (~320px) using shadcn/ui `Sheet`, toggled by a header button, hidden on mobile
-- [ ] Build mobile `FilterOverlay` component: full-screen overlay with open/close toggle button, visible only on mobile (<768px)
+- [x] Build mobile `FilterOverlay` component: full-screen overlay with open/close toggle button, visible only on mobile (<768px)
 - [ ] Build `SummaryBar` component: persistent bar with placeholder crash count and empty filter badge area, visible on all screen sizes
 - [ ] Wire `map.resize()` to sidebar and overlay open/close transitions
 - [ ] Smoke test responsive layout at mobile (<768px) and desktop (≥768px) breakpoints

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-18 — Mobile Filter Overlay Scaffold
+
+- Created `components/overlay/FilterOverlay.tsx` — full-screen fixed overlay (`md:hidden`), with header, close button, and scrollable content area; renders `null` when closed
+- Updated `AppShell.tsx` — added `overlayOpen` state and a mobile-only floating toggle button (`md:hidden`) at the same position as the desktop button; both swap cleanly at the `md` breakpoint
+
 ### 2026-02-17 — Apollo Client Setup (Phase 3 Start)
 
 - Installed `@apollo/client` and `@apollo/client-integration-nextjs` (the current successor to the deprecated `@apollo/experimental-nextjs-app-support`)

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -4,10 +4,12 @@ import { useState } from 'react'
 import { SlidersHorizontal } from 'lucide-react'
 import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
+import { FilterOverlay } from '@/components/overlay/FilterOverlay'
 import { Button } from '@/components/ui/button'
 
 export function AppShell() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [overlayOpen, setOverlayOpen] = useState(false)
 
   return (
     <>
@@ -25,7 +27,20 @@ export function AppShell() {
         </Button>
       </div>
 
+      {/* Filter overlay toggle button — mobile only */}
+      <div className="absolute top-4 right-4 z-10 md:hidden">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setOverlayOpen(true)}
+          aria-label="Open filters"
+        >
+          <SlidersHorizontal className="size-4" />
+        </Button>
+      </div>
+
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <FilterOverlay isOpen={overlayOpen} onClose={() => setOverlayOpen(false)} />
     </>
   )
 }

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface FilterOverlayProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-20 flex flex-col bg-background md:hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Filters"
+    >
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h2 className="text-base font-semibold">Filters</h2>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close filters">
+          <X className="size-4" />
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <p className="text-sm text-muted-foreground">Filter controls coming soon.</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Merge 1st

- Created `components/overlay/FilterOverlay.tsx` — full-screen fixed overlay (`md:hidden`), with header, close button, and scrollable content area; renders `null` when closed
- Updated `AppShell.tsx` — added `overlayOpen` state and a mobile-only floating toggle button (`md:hidden`) at the same position as the desktop button; both swap cleanly at the `md` breakpoint

Closes #30 