### PR TITLE
Wire map.resize() to Sidebar and Overlay Transitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Build desktop `Sidebar` component: fixed right panel (~320px) using shadcn/ui `Sheet`, toggled by a header button, hidden on mobile
 - [x] Build mobile `FilterOverlay` component: full-screen overlay with open/close toggle button, visible only on mobile (<768px)
 - [x] Build `SummaryBar` component: persistent bar with placeholder crash count and empty filter badge area, visible on all screen sizes
-- [ ] Wire `map.resize()` to sidebar and overlay open/close transitions
+- [x] Wire `map.resize()` to sidebar and overlay open/close transitions
 - [ ] Smoke test responsive layout at mobile (<768px) and desktop (≥768px) breakpoints
 - [ ] Import Domain into Render settings
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.3.6
+**Version:** 0.3.7
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-18 — Wire map.resize() to Sidebar and Overlay Transitions
+
+- Converted `MapContainer` to a `forwardRef` component so the Mapbox `MapRef` can be held in `AppShell`
+- Added `mapRef = useRef<MapRef>(null)` in `AppShell`; `useEffect` watching `[sidebarOpen, overlayOpen]` calls `mapRef.current?.resize()` after a 300ms delay to let the Sheet slide animation complete before Mapbox recomputes canvas bounds
+- `MapRef` imported from `react-map-gl/mapbox` (root `react-map-gl` is not resolvable as a module in this project setup)
 
 ### 2026-02-18 — SummaryBar Component
 

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useEffect, useState } from 'react'
 import { SlidersHorizontal } from 'lucide-react'
+import type { MapRef } from 'react-map-gl/mapbox'
 import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
 import { FilterOverlay } from '@/components/overlay/FilterOverlay'
@@ -11,10 +12,18 @@ import { Button } from '@/components/ui/button'
 export function AppShell() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [overlayOpen, setOverlayOpen] = useState(false)
+  const mapRef = useRef<MapRef>(null)
+
+  // Call resize() after sidebar/overlay transitions so Mapbox recomputes canvas size.
+  // 300ms matches the shadcn Sheet slide animation duration.
+  useEffect(() => {
+    const id = setTimeout(() => mapRef.current?.resize(), 300)
+    return () => clearTimeout(id)
+  }, [sidebarOpen, overlayOpen])
 
   return (
     <>
-      <MapContainer />
+      <MapContainer ref={mapRef} />
 
       {/* Sidebar toggle button — desktop only */}
       <div className="absolute top-4 right-4 z-10 hidden md:block">

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -1,14 +1,17 @@
 'use client'
 
+import { forwardRef } from 'react'
 import Map from 'react-map-gl/mapbox'
+import type { MapRef } from 'react-map-gl/mapbox'
 
-export function MapContainer() {
+export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
   return (
     <Map
+      ref={ref}
       mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
       initialViewState={{ longitude: -120.5, latitude: 47.5, zoom: 7 }}
       style={{ width: '100%', height: '100%' }}
       mapStyle="mapbox://styles/mapbox/light-v11"
     />
   )
-}
+})


### PR DESCRIPTION
- Converted `MapContainer` to a `forwardRef` component so the Mapbox `MapRef` can be held in `AppShell`
- Added `mapRef = useRef<MapRef>(null)` in `AppShell`; `useEffect` watching `[sidebarOpen, overlayOpen]` calls `mapRef.current?.resize()` after a 300ms delay to let the Sheet slide animation complete before Mapbox recomputes canvas bounds
- `MapRef` imported from `react-map-gl/mapbox` (root `react-map-gl` is not resolvable as a module in this project setup)

Closes #32 