### PR TITLE
Add Light/Dark Mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,9 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - `lib/graphql/__tests__/helpers.test.ts` — Unit tests for `rawToBucket`, `bucketsToRawValues`, `buildWhere`
 - `lib/graphql/__tests__/queries.test.ts` — Integration tests for all GraphQL queries via `executeOperation` with mocked Prisma
 - `vitest.config.ts` — Vitest configuration with `@` path alias
-- `components/layout/AppShell.tsx` — `'use client'` layout orchestrator; owns sidebar/overlay open state, renders SummaryBar
+- `components/theme-provider.tsx` — thin `NextThemesProvider` wrapper (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
+- `components/ui/theme-toggle.tsx` — Sun/Moon icon button; CSS-driven icon swap via `dark:hidden`/`hidden dark:block`
+- `components/layout/AppShell.tsx` — `'use client'` layout orchestrator; owns sidebar/overlay open state, renders SummaryBar and ThemeToggle
 - `components/map/MapContainer.tsx` — `'use client'` Mapbox map filling parent container
 - `components/sidebar/Sidebar.tsx` — Sheet-based right panel (desktop, ≥768px)
 - `components/overlay/FilterOverlay.tsx` — Full-screen filter overlay (mobile, <768px)
@@ -259,7 +261,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
   - Import `Map` from `react-map-gl/mapbox` (required for mapbox-gl >= 3.5)
   - `mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}`
   - `initialViewState`: longitude -120.5, latitude 47.5, zoom 7 (Washington state)
-  - `mapStyle="mapbox://styles/mapbox/light-v11"` — clean light basemap for data visualization
+  - `mapStyle` — dynamic: `light-v11` or `dark-v11` based on `useTheme()` from `next-themes`
   - `style={{ width: '100%', height: '100%' }}` — fills parent; parent owns `100dvh`
 - [x] Build desktop `Sidebar` component: fixed right panel (~320px) using shadcn/ui `Sheet`, toggled by a header button, hidden on mobile
 - [x] Build mobile `FilterOverlay` component: full-screen overlay with open/close toggle button, visible only on mobile (<768px)
@@ -267,7 +269,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Wire `map.resize()` to sidebar and overlay open/close transitions
 - [x] Smoke test responsive layout at mobile (<768px) and desktop (≥768px) breakpoints
 - [x] Set default zoom for mobile to the city of Seattle
-- [ ] Import Domain into Render settings
+- [x] Light/Dark mode — `next-themes` provider, Sun/Moon toggle button, dynamic Mapbox style swap (`light-v11` ↔ `dark-v11`)
 
 #### Milestone: Interactive map with filters
 
@@ -293,6 +295,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 #### Milestone: Production-ready public application
 
+- [ ] Import Domain into Render settings
 - [ ] Add rate limiting middleware for public API abuse prevention
 - [ ] Configure CSP headers and CORS in Next.js
 - [ ] Add loading states, error boundaries, skeleton screens
@@ -315,7 +318,6 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [ ] Gather user feedback and iterate on visualizations
 - [ ] **Stretch goal: Dashboard charts** (see Section 11) — add Recharts/D3 visualizations for severity, mode, time trends, and geographic breakdowns
 - [ ] **Stretch goal: Mobile bottom sheet** (see Section 11) — upgrade from full-screen overlay using `vaul` or `react-modal-sheet` for peek/half/full snap states
-- [ ] **Stretch goal: Light/Dark mode** (see Section 11) — swap Mapbox basemap, chart themes, and UI via CSS custom properties
 - [ ] Add comparative analysis features (year-over-year, area comparison)
 - [ ] Add an admin interface for uploading new crash data (protected with NextAuth.js)
 - [ ] Monitor query performance — add materialized views only if aggregation queries become slow

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # CrashMap
 
-**Version:** 0.3.7
-**Version:** 0.3.7
+**Version:** 0.3.8
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -77,6 +76,15 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Created `components/map/MapContainer.tsx` — `'use client'` component with `react-map-gl/mapbox`, centered on Washington state, `light-v11` basemap
 - Replaced `app/page.tsx` boilerplate with a full-viewport layout (`100dvh`, `position: relative` for future overlays)
 - Added `devIndicators: false` to `next.config.ts` to suppress the Next.js dev-mode badge overlapping the map
+
+### 2026-02-19 — Light/Dark Mode
+
+- Installed `next-themes` for system-preference detection and localStorage persistence
+- Created `components/theme-provider.tsx` — thin `NextThemesProvider` wrapper (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
+- Created `components/ui/theme-toggle.tsx` — Sun/Moon icon button using `useTheme()`; CSS-driven icon swap avoids hydration flash
+- Updated `app/layout.tsx` — added `ThemeProvider` wrapper and `suppressHydrationWarning` on `<html>`
+- Updated `components/map/MapContainer.tsx` — swaps Mapbox basemap between `light-v11` and `dark-v11` based on `resolvedTheme`
+- Updated `components/layout/AppShell.tsx` — consolidated top-right controls into a single flex container with ThemeToggle alongside filter button
 
 ### 2026-02-18 — Mapbox Token Configured
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { ApolloProvider } from './apollo-provider'
+import { ThemeProvider } from '@/components/theme-provider'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './globals.css'
 
@@ -25,9 +26,16 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ApolloProvider>{children}</ApolloProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <ApolloProvider>{children}</ApolloProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { Sidebar } from '@/components/sidebar/Sidebar'
 import { FilterOverlay } from '@/components/overlay/FilterOverlay'
 import { SummaryBar } from '@/components/summary/SummaryBar'
 import { Button } from '@/components/ui/button'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
 
 export function AppShell() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -25,28 +26,31 @@ export function AppShell() {
     <>
       <MapContainer ref={mapRef} />
 
-      {/* Sidebar toggle button — desktop only */}
-      <div className="absolute top-4 right-4 z-10 hidden md:block">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open filters"
-        >
-          <SlidersHorizontal className="size-4" />
-        </Button>
-      </div>
-
-      {/* Filter overlay toggle button — mobile only */}
-      <div className="absolute top-4 right-4 z-10 md:hidden">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => setOverlayOpen(true)}
-          aria-label="Open filters"
-        >
-          <SlidersHorizontal className="size-4" />
-        </Button>
+      {/* Top-right controls */}
+      <div className="absolute top-4 right-4 z-10 flex gap-2">
+        <ThemeToggle />
+        {/* Sidebar toggle — desktop only */}
+        <div className="hidden md:block">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open filters"
+          >
+            <SlidersHorizontal className="size-4" />
+          </Button>
+        </div>
+        {/* Filter overlay toggle — mobile only */}
+        <div className="md:hidden">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setOverlayOpen(true)}
+            aria-label="Open filters"
+          >
+            <SlidersHorizontal className="size-4" />
+          </Button>
+        </div>
       </div>
 
       <SummaryBar />

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -2,14 +2,21 @@
 
 import { forwardRef } from 'react'
 import Map from 'react-map-gl/mapbox'
-
-const DESKTOP_VIEW = { longitude: -120.5, latitude: 47.5, zoom: 7 }
-const MOBILE_VIEW = { longitude: -122.3321, latitude: 47.6062, zoom: 11 }
 import type { MapRef } from 'react-map-gl/mapbox'
+import { useTheme } from 'next-themes'
+
+const DESKTOP_VIEW = { longitude: -120.9, latitude: 47.32, zoom: 6.9 }
+const MOBILE_VIEW = { longitude: -122.336, latitude: 47.6062, zoom: 10.25 }
 
 export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
   const initialViewState = isMobile ? MOBILE_VIEW : DESKTOP_VIEW
+
+  const { resolvedTheme } = useTheme()
+  const mapStyle =
+    resolvedTheme === 'dark'
+      ? 'mapbox://styles/mapbox/dark-v11'
+      : 'mapbox://styles/mapbox/light-v11'
 
   return (
     <Map
@@ -17,7 +24,7 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
       mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
       initialViewState={initialViewState}
       style={{ width: '100%', height: '100%' }}
-      mapStyle="mapbox://styles/mapbox/light-v11"
+      mapStyle={mapStyle}
     />
   )
 })

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import * as React from 'react'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Moon, Sun } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme()
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+      aria-label="Toggle theme"
+    >
+      <Sun className="size-4 dark:hidden" />
+      <Moon className="size-4 hidden dark:block" />
+    </Button>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "lucide-react": "^0.574.0",
         "mapbox-gl": "^3.18.1",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-day-picker": "^9.13.2",
@@ -14004,6 +14005,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lucide-react": "^0.574.0",
     "mapbox-gl": "^3.18.1",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-day-picker": "^9.13.2",


### PR DESCRIPTION
- Installed `next-themes` for system-preference detection and localStorage persistence
- Created `components/theme-provider.tsx` — thin `NextThemesProvider` wrapper (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
- Created `components/ui/theme-toggle.tsx` — Sun/Moon icon button using `useTheme()`; CSS-driven icon swap avoids hydration flash
- Updated `app/layout.tsx` — added `ThemeProvider` wrapper and `suppressHydrationWarning` on `<html>`
- Updated `components/map/MapContainer.tsx` — swaps Mapbox basemap between `light-v11` and `dark-v11` based on `resolvedTheme`
- Updated `components/layout/AppShell.tsx` — consolidated top-right controls into a single flex container with ThemeToggle alongside filter button

Closes #67