### PR TITLE
Add GeoJSON Data Layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # PostgreSQL connection string — set in Render dashboard, never commit the real value
-DATABASE_URL="postgresql://user:password@host/database"
+DATABASE_URL="postgresql://user:password@host/database?sslmode=require"
 
 # Mapbox public access token — get from mapbox.com/account/access-tokens
 NEXT_PUBLIC_MAPBOX_TOKEN="pk.eyJ1IjoiLi4uIn0..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,21 +273,21 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 #### Milestone: Interactive map with filters
 
-- [ ] Build interactive map component with Mapbox GL JS (`react-map-gl`):
-  - GeoJSON source built from `Latitude`/`Longitude` fields
-  - Circle layer with severity-based color/opacity gradient (see Section 4 for palette)
-  - Stroke color differentiation for bicyclist vs. pedestrian mode
-  - None/Unknown injuries hidden by default via Mapbox layer filter
-  - Heatmap layer for density visualization at low zoom levels
-  - Built-in clustering with `cluster: true` on the GeoJSON source
-  - Popup/tooltip on click showing crash details (date, severity, mode, location, age group)
-- [ ] Implement filter panel (see Section 4 for full spec):
-  - Date Range: year quick-select buttons (most recent 4 years) + custom date range picker
-  - State → County → City cascading dropdowns (powered by `filter_metadata` view)
-  - Mode toggle: Bicyclist / Pedestrian / All
-  - Severity multi-select: Death, Serious, Minor (None/Unknown opt-in)
+- [x] Add GeoJSON data layer — fetch crashes via GraphQL and render as a basic circle layer on the map using `Latitude`/`Longitude` fields
+- [ ] Add severity-based circle styling — color, opacity, and size gradient per injury bucket (Death → Major → Minor → None) using Mapbox `interpolate` expressions; sizes scale with zoom
+- [ ] Add mode stroke differentiation — stroke color distinguishes bicyclists (blue `#1565C0`) vs. pedestrians (purple `#4A148C`); stroke width scales with zoom
+- [ ] Hide None/Unknown injuries by default — Mapbox layer filter excludes the None bucket on initial load
+- [ ] Add crash detail popup — click a circle to show a tooltip with date, severity, mode, location, and age group
+- [ ] Add clustering — enable `cluster: true` on the GeoJSON source; cluster circles collapse at low zoom with count labels
+- [ ] Add heatmap layer — density heatmap visible at low zoom levels, hidden as zoom increases
+- [ ] Add filter state context — React Context with state + dispatch for all filters (mode, severity, date range, geo); no UI yet, just the shared state layer all filter components will consume
+- [ ] Add mode toggle filter — `ToggleGroup` in sidebar/overlay for Bicyclist / Pedestrian / All; wired to filter context
+- [ ] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
+- [ ] Add date range quick-select — four year buttons (most recent 4 years) that set the date filter in context
+- [ ] Add date range custom picker — `Popover` + `Calendar` for arbitrary start/end date selection; shares the same date filter state as quick-select buttons
 - [ ] Load filter options on app init via `filterOptions` GraphQL query
-- [ ] Connect filters to GraphQL query variables
+- [ ] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
+- [ ] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change
 
 **Deliverables:** Working app with map and filters
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.3.8
+**Version:** 0.4.0
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -45,6 +45,24 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — GeoJSON Data Layer
+
+- Created `lib/graphql/queries.ts` with `GET_CRASHES` Apollo query document
+- Created `components/map/CrashLayer.tsx` — fetches up to 5000 crashes via `useQuery`, converts to GeoJSON FeatureCollection, renders Mapbox `Source` + circle `Layer`
+- Updated `MapContainer.tsx` to render `<CrashLayer />` inside `<Map>`
+- Fixed Apollo Client v4 import paths: `useQuery` → `@apollo/client/react`; `HttpLink` → `@apollo/client/link/http`
+- Fixed `PrismaPg` constructor: pass `{ connectionString }` PoolConfig instead of raw string
+- Added `?sslmode=require` to `DATABASE_URL` for SSL-required Render external connections
+
+### 2026-02-19 — Light/Dark Mode
+
+- Installed `next-themes` for system-preference detection and localStorage persistence
+- Created `components/theme-provider.tsx` — thin `NextThemesProvider` wrapper (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
+- Created `components/ui/theme-toggle.tsx` — Sun/Moon icon button using `useTheme()`; CSS-driven icon swap avoids hydration flash
+- Updated `app/layout.tsx` — added `ThemeProvider` wrapper and `suppressHydrationWarning` on `<html>`
+- Updated `components/map/MapContainer.tsx` — swaps Mapbox basemap between `light-v11` and `dark-v11` based on `resolvedTheme`
+- Updated `components/layout/AppShell.tsx` — consolidated top-right controls into a single flex container with ThemeToggle alongside filter button
+
 ### 2026-02-18 — Mobile Default Zoom
 
 - Set `MapContainer` default view to Seattle (longitude -122.3321, latitude 47.6062, zoom 11) on mobile (<768px); Washington state view unchanged on desktop
@@ -76,15 +94,6 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Created `components/map/MapContainer.tsx` — `'use client'` component with `react-map-gl/mapbox`, centered on Washington state, `light-v11` basemap
 - Replaced `app/page.tsx` boilerplate with a full-viewport layout (`100dvh`, `position: relative` for future overlays)
 - Added `devIndicators: false` to `next.config.ts` to suppress the Next.js dev-mode badge overlapping the map
-
-### 2026-02-19 — Light/Dark Mode
-
-- Installed `next-themes` for system-preference detection and localStorage persistence
-- Created `components/theme-provider.tsx` — thin `NextThemesProvider` wrapper (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
-- Created `components/ui/theme-toggle.tsx` — Sun/Moon icon button using `useTheme()`; CSS-driven icon swap avoids hydration flash
-- Updated `app/layout.tsx` — added `ThemeProvider` wrapper and `suppressHydrationWarning` on `<html>`
-- Updated `components/map/MapContainer.tsx` — swaps Mapbox basemap between `light-v11` and `dark-v11` based on `resolvedTheme`
-- Updated `components/layout/AppShell.tsx` — consolidated top-right controls into a single flex container with ThemeToggle alongside filter button
 
 ### 2026-02-18 — Mapbox Token Configured
 

--- a/app/apollo-provider.tsx
+++ b/app/apollo-provider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { HttpLink } from '@apollo/client'
+import { HttpLink } from '@apollo/client/link/http'
 import {
   ApolloClient,
   ApolloNextAppProvider,

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useQuery } from '@apollo/client/react'
+import { Source, Layer } from 'react-map-gl/mapbox'
+import type { LayerProps } from 'react-map-gl/mapbox'
+import type { FeatureCollection, Point } from 'geojson'
+import { GET_CRASHES } from '@/lib/graphql/queries'
+
+type CrashItem = {
+  colliRptNum: string
+  latitude: number | null
+  longitude: number | null
+  severity: string | null
+  mode: string | null
+  crashDate: string | null
+}
+
+type GetCrashesQuery = {
+  crashes: {
+    items: CrashItem[]
+    totalCount: number
+  }
+}
+
+const circleLayer: LayerProps = {
+  id: 'crashes-circles',
+  type: 'circle',
+  paint: {
+    'circle-radius': 5,
+    'circle-color': '#B71C1C',
+    'circle-opacity': 0.7,
+  },
+}
+
+export function CrashLayer() {
+  const { data, error } = useQuery<GetCrashesQuery>(GET_CRASHES, {
+    variables: { limit: 5000 },
+  })
+
+  if (error) {
+    console.error('CrashLayer query error:', error)
+    return null
+  }
+
+  if (!data) return null
+
+  const geojson: FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: data.crashes.items
+      .filter(
+        (crash: { latitude: number | null; longitude: number | null }) =>
+          crash.latitude != null && crash.longitude != null
+      )
+      .map((crash) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [crash.longitude!, crash.latitude!],
+        },
+        properties: {
+          colliRptNum: crash.colliRptNum,
+          severity: crash.severity,
+          mode: crash.mode,
+          crashDate: crash.crashDate,
+        },
+      })),
+  }
+
+  return (
+    <Source id="crashes" type="geojson" data={geojson}>
+      <Layer {...circleLayer} />
+    </Source>
+  )
+}

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from 'react'
 import Map from 'react-map-gl/mapbox'
 import type { MapRef } from 'react-map-gl/mapbox'
 import { useTheme } from 'next-themes'
+import { CrashLayer } from './CrashLayer'
 
 const DESKTOP_VIEW = { longitude: -120.9, latitude: 47.32, zoom: 6.9 }
 const MOBILE_VIEW = { longitude: -122.336, latitude: 47.6062, zoom: 10.25 }
@@ -25,6 +26,8 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
       initialViewState={initialViewState}
       style={{ width: '100%', height: '100%' }}
       mapStyle={mapStyle}
-    />
+    >
+      <CrashLayer />
+    </Map>
   )
 })

--- a/lib/apollo-client.ts
+++ b/lib/apollo-client.ts
@@ -1,4 +1,4 @@
-import { HttpLink } from '@apollo/client'
+import { HttpLink } from '@apollo/client/link/http'
 import {
   ApolloClient,
   InMemoryCache,

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client'
+
+export const GET_CRASHES = gql`
+  query GetCrashes($filter: CrashFilter, $limit: Int) {
+    crashes(filter: $filter, limit: $limit) {
+      items {
+        colliRptNum
+        latitude
+        longitude
+        severity
+        mode
+        crashDate
+      }
+      totalCount
+    }
+  }
+`

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -5,7 +5,7 @@ import { PrismaPg } from '@prisma/adapter-pg'
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined }
 
 function createPrismaClient() {
-  const adapter = new PrismaPg(process.env.DATABASE_URL!)
+  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! })
   return new PrismaClient({ adapter })
 }
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -2596,7 +2596,6 @@ In `components/map/MapContainer.tsx`, convert `<Map />` to a parent element:
 
 ```tsx
 import { CrashLayer } from './CrashLayer'
-
 ;<Map ref={ref} /* ...other props... */>
   <CrashLayer />
 </Map>

--- a/tutorial.md
+++ b/tutorial.md
@@ -2466,4 +2466,190 @@ npm test        # all tests still pass
 
 ---
 
+---
+
+## Phase 3 (continued): Interactive Map with Data
+
+### Step: Add the GeoJSON Data Layer
+
+At this point the map renders a beautiful basemap but no crash data. The next step fetches crashes from our GraphQL API and renders them as circle points on the map.
+
+#### Architecture decision: load all data client-side
+
+Rather than re-querying the API whenever a filter changes, we load up to 5,000 crashes once as a GeoJSON FeatureCollection and let Mapbox filter them with layer expressions. This keeps the map snappy and avoids round-trips for every interaction.
+
+#### Step 1: Create the query document
+
+Create `lib/graphql/queries.ts`. Only request the fields needed for map rendering:
+
+```ts
+import { gql } from '@apollo/client'
+
+export const GET_CRASHES = gql`
+  query GetCrashes($filter: CrashFilter, $limit: Int) {
+    crashes(filter: $filter, limit: $limit) {
+      items {
+        colliRptNum
+        latitude
+        longitude
+        severity
+        mode
+        crashDate
+      }
+      totalCount
+    }
+  }
+`
+```
+
+We store `severity`, `mode`, and `crashDate` as GeoJSON feature properties even though we don't use them for styling yet — they'll be available for Mapbox layer expressions in the next steps.
+
+#### Step 2: Create the CrashLayer component
+
+Create `components/map/CrashLayer.tsx`:
+
+```tsx
+'use client'
+
+import { useQuery } from '@apollo/client/react'
+import { Source, Layer } from 'react-map-gl/mapbox'
+import type { LayerProps } from 'react-map-gl/mapbox'
+import type { FeatureCollection, Point } from 'geojson'
+import { GET_CRASHES } from '@/lib/graphql/queries'
+
+type CrashItem = {
+  colliRptNum: string
+  latitude: number | null
+  longitude: number | null
+  severity: string | null
+  mode: string | null
+  crashDate: string | null
+}
+
+type GetCrashesQuery = {
+  crashes: {
+    items: CrashItem[]
+    totalCount: number
+  }
+}
+
+const circleLayer: LayerProps = {
+  id: 'crashes-circles',
+  type: 'circle',
+  paint: {
+    'circle-radius': 5,
+    'circle-color': '#B71C1C',
+    'circle-opacity': 0.7,
+  },
+}
+
+export function CrashLayer() {
+  const { data, error } = useQuery<GetCrashesQuery>(GET_CRASHES, {
+    variables: { limit: 5000 },
+  })
+
+  if (error) {
+    console.error('CrashLayer query error:', error)
+    return null
+  }
+
+  if (!data) return null
+
+  const geojson: FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: data.crashes.items
+      .filter((crash) => crash.latitude != null && crash.longitude != null)
+      .map((crash) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [crash.longitude!, crash.latitude!],
+        },
+        properties: {
+          colliRptNum: crash.colliRptNum,
+          severity: crash.severity,
+          mode: crash.mode,
+          crashDate: crash.crashDate,
+        },
+      })),
+  }
+
+  return (
+    <Source id="crashes" type="geojson" data={geojson}>
+      <Layer {...circleLayer} />
+    </Source>
+  )
+}
+```
+
+Key points:
+
+- **`useQuery` import**: In Apollo Client v4, React hooks moved to `@apollo/client/react` (not `@apollo/client`).
+- **`LayerProps` type**: `react-map-gl/mapbox` does not export `CircleLayer`. The correct type for what `<Layer>` accepts is `LayerProps` from `react-map-gl/mapbox`.
+- **GeoJSON coordinates are `[longitude, latitude]`** (x, y — longitude-first per the GeoJSON spec).
+- **Non-null assertions after filter**: TypeScript doesn't narrow after `.filter()`, so use `crash.longitude!` / `crash.latitude!` since the filter already guarantees non-null.
+- **Loading state**: Return `null` while `data` is undefined — the map stays visible with no spinner needed.
+
+#### Step 3: Render CrashLayer inside the Map
+
+In `components/map/MapContainer.tsx`, convert `<Map />` to a parent element:
+
+```tsx
+import { CrashLayer } from './CrashLayer'
+
+;<Map ref={ref} /* ...other props... */>
+  <CrashLayer />
+</Map>
+```
+
+Children of react-map-gl's `<Map>` are rendered into the map's canvas context — this is the correct pattern for `Source` and `Layer` components.
+
+#### Pitfall: Apollo Client v4 import changes
+
+Apollo Client v4 moved several exports to dedicated subpaths (breaking change from v3):
+
+| Export                          | v3               | v4                           |
+| ------------------------------- | ---------------- | ---------------------------- |
+| `useQuery`, `useMutation`, etc. | `@apollo/client` | `@apollo/client/react`       |
+| `HttpLink`                      | `@apollo/client` | `@apollo/client/link/http`   |
+| `gql`                           | `@apollo/client` | `@apollo/client` (unchanged) |
+
+Update all files importing `HttpLink` (`lib/apollo-client.ts`, `app/apollo-provider.tsx`) and all React hook imports.
+
+#### Pitfall: PrismaPg requires a PoolConfig, not a raw string
+
+The `@prisma/adapter-pg` constructor signature is `pg.Pool | pg.PoolConfig` — it never accepted a raw string. Passing one causes:
+
+```text
+Cannot use 'in' operator to search for 'password' in postgresql://...
+```
+
+This happens because `pg` internally does `'password' in config` to detect a config object, and `in` throws on a primitive string.
+
+```ts
+// Wrong:
+new PrismaPg(process.env.DATABASE_URL!)
+
+// Correct:
+new PrismaPg({ connectionString: process.env.DATABASE_URL! })
+```
+
+#### Pitfall: Render external connections require SSL
+
+After fixing the adapter, the next error was `User was denied access on the database (not available)`. The `(not available)` is Prisma's signal that it couldn't establish a connection at all. The cause: Render's PostgreSQL requires SSL for all external connections (local dev). Internal connections (Render app to Render DB) work without it, which is why the deployed app was unaffected.
+
+Fix: append `?sslmode=require` to `DATABASE_URL` in your local `.env`:
+
+```text
+DATABASE_URL="postgresql://user:password@host/database?sslmode=require"
+```
+
+Restart `npm run dev` after changing `.env` — Next.js does not hot-reload environment variable changes.
+
+#### Verify Loading
+
+Open the map after `npm run dev`. Thousands of dark-red dots should appear across Washington state. Check the Network tab: one `POST /api/graphql` for `GetCrashes` on page load.
+
+---
+
 _This tutorial is a work in progress. More steps will be added as the project progresses._


### PR DESCRIPTION
- Created `lib/graphql/queries.ts` with `GET_CRASHES` Apollo query document
- Created `components/map/CrashLayer.tsx` — fetches up to 5000 crashes via `useQuery`, converts to GeoJSON FeatureCollection, renders Mapbox `Source` + circle `Layer`
- Updated `MapContainer.tsx` to render `<CrashLayer />` inside `<Map>`
- Fixed Apollo Client v4 import paths: `useQuery` → `@apollo/client/react`; `HttpLink` → `@apollo/client/link/http`
- Fixed `PrismaPg` constructor: pass `{ connectionString }` PoolConfig instead of raw string
- Added `?sslmode=require` to `DATABASE_URL` for SSL-required Render external connections

Closes #69