### PR TITLE
Line Ending Normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for all text files on all platforms
+* text=auto eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Validate data: check for null `Latitude`/`Longitude` values, confirm `Mode` values are consistent ("Bicyclist"/"Pedestrian"), check `MostSevereInjuryType` distinct values
 - [x] Create the `filter_metadata` and `available_years` materialized views (see Section 4) for cascading dropdown population
 - [x] Set up ESLint, Prettier, Husky pre-commit hooks
+- [x] Add `.gitattributes` enforcing `eol=lf` — fixes Prettier `format:check` failures on Windows (`core.autocrlf=true` converts LF→CRLF on checkout; `eol=lf` overrides it)
 
 **Deliverables:** Running Next.js app, populated database, Prisma client generated
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — Line Ending Normalization
+
+- Added `.gitattributes` enforcing LF line endings on all platforms, fixing Prettier `format:check` failures on Windows caused by `git core.autocrlf=true` converting LF → CRLF on checkout
+
 ### 2026-02-19 — GeoJSON Data Layer
 
 - Created `lib/graphql/queries.ts` with `GET_CRASHES` Apollo query document


### PR DESCRIPTION
- Added `.gitattributes` enforcing LF line endings on all platforms, fixing Prettier `format:check` failures on Windows caused by `git core.autocrlf=true` converting LF → CRLF on checkout


Closes #85 