### PR TITLE
Prisma Schema Fix: Remove geom from schema.prisma

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ CREATE TABLE public.crashdata
   - **None**: "No Apparent Injury", "Unknown"
   - Additional values may appear as more data sources are imported — always map dynamically
 - Prisma model uses `@map` decorators to map camelCase TS properties to the existing PascalCase column names
-- A generated PostGIS `geom` column exists for spatial queries (see ARCHITECTURE.md Section 3)
+- A generated PostGIS `geom` column exists in the database for spatial queries, but it is **not** in `schema.prisma` — Prisma 7's WASM compiler throws a `PrismaClientValidationError` on any `findMany()` when an `Unsupported` type field is present; use `prisma.$queryRaw` for raw spatial queries
 
 ### Prisma 7 Client Notes
 
@@ -206,7 +206,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Initialize Tailwind CSS and shadcn/ui (`npx shadcn-ui@latest init`)
 - [x] Set up PostgreSQL with PostGIS extension on your existing Render database (`CREATE EXTENSION postgis;`)
 - [x] Run `prisma db pull` to introspect your existing `crashdata` table, then refine the generated Prisma model (see Section 3 for the recommended model)
-- [x] Add the generated `geom` geometry column and create recommended indexes (see Section 3)
+- [x] Add the generated `geom` geometry column and create recommended indexes (see Section 3) — column exists in DB; removed from `schema.prisma` (Prisma 7 WASM compiler bug with `Unsupported` type)
 - [x] Verify `FullDate` column format (ISO 8601: `2025-02-23T00:00:00`) and add `CrashDate` DATE column with index
 - [x] Validate data: check for null `Latitude`/`Longitude` values, confirm `Mode` values are consistent ("Bicyclist"/"Pedestrian"), check `MostSevereInjuryType` distinct values
 - [x] Create the `filter_metadata` and `available_years` materialized views (see Section 4) for cascading dropdown population

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.4.0
+**Version:** 0.4.1
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-19 — Prisma Schema Fix: Remove geom from schema.prisma
+
+- Removed `geom Unsupported("geometry")` field and its `@@index([geom], type: Gist)` from `prisma/schema.prisma`
+- Root cause: Prisma 7's new WASM-based `prisma-client` generator throws a `PrismaClientValidationError` (empty message body) on any `findMany()` call when an `Unsupported` type field is present in the model — diagnosed from the 10ms response time confirming the error occurred before any database query
+- The `geom` column and GiST index remain intact in the database; raw spatial queries via `prisma.$queryRaw` are unaffected
 
 ### 2026-02-19 — Line Ending Normalization
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,13 +25,11 @@ model CrashData {
   longitude            Float?                   @map("Longitude")
   mode                 String?                  @map("Mode")
   crashDate            DateTime?                @map("CrashDate") @db.Date
-  geom                 Unsupported("geometry")? @default(dbgenerated("st_setsrid(st_makepoint(\"Longitude\", \"Latitude\"), 4326)"))
 
   @@index([crashDate], map: "idx_crashdata_date")
   @@index([cityName], map: "idx_crashdata_city")
   @@index([countyName], map: "idx_crashdata_county")
-  @@index([geom], map: "idx_crashdata_geom", type: Gist)
-  @@index([mode], map: "idx_crashdata_mode")
+@@index([mode], map: "idx_crashdata_mode")
   @@index([mostSevereInjuryType], map: "idx_crashdata_severity")
   @@index([stateOrProvinceName], map: "idx_crashdata_state")
   @@map("crashdata")

--- a/tutorial.md
+++ b/tutorial.md
@@ -312,9 +312,7 @@ With the database updated, pull the new schema into Prisma:
 npx prisma db pull
 ```
 
-Prisma doesn't have a native PostGIS geometry type, so the `geom` column is represented as `Unsupported("geometry")`. That's expected — you can still read it using `prisma.$queryRaw` for raw spatial queries. Importantly, Prisma did pick up the GIST index (`type: Gist`), so the full index set is reflected in the schema.
-
-The new field and indexes in `prisma/schema.prisma`:
+Prisma doesn't have a native PostGIS geometry type, so the `geom` column is represented as `Unsupported("geometry")`. Prisma did pick up the GIST index (`type: Gist`), so after the pull, the schema will look like this:
 
 ```prisma
 geom Unsupported("geometry")? @default(dbgenerated("st_setsrid(st_makepoint(\"Longitude\", \"Latitude\"), 4326)"))
@@ -323,6 +321,23 @@ geom Unsupported("geometry")? @default(dbgenerated("st_setsrid(st_makepoint(\"Lo
 @@index([cityName], map: "idx_crashdata_city")
 @@index([countyName], map: "idx_crashdata_county")
 @@index([geom], map: "idx_crashdata_geom", type: Gist)
+@@index([mode], map: "idx_crashdata_mode")
+@@index([mostSevereInjuryType], map: "idx_crashdata_severity")
+@@index([stateOrProvinceName], map: "idx_crashdata_state")
+```
+
+> **Important — remove `geom` from `schema.prisma` before continuing.**
+>
+> Prisma 7's new WASM-based `prisma-client` generator has a bug: when an `Unsupported` type field is present in a model, it throws a `PrismaClientValidationError` with an empty message body on _any_ `findMany()` or `findUnique()` call — even if the query never touches that field. This error surfaces at the Prisma query-construction stage, before any database query is sent (you'll see ~10ms response times, confirming nothing reached PostgreSQL).
+>
+> The fix is to remove the `geom` field and its index from `schema.prisma`. The column and GiST index remain intact in the database — PostgreSQL still maintains the generated geometry and the spatial index. If you need spatial queries in the future, use `prisma.$queryRaw` to access `geom` directly.
+
+After removing those two lines, `schema.prisma` should have only these indexes:
+
+```prisma
+@@index([crashDate], map: "idx_crashdata_date")
+@@index([cityName], map: "idx_crashdata_city")
+@@index([countyName], map: "idx_crashdata_county")
 @@index([mode], map: "idx_crashdata_mode")
 @@index([mostSevereInjuryType], map: "idx_crashdata_severity")
 @@index([stateOrProvinceName], map: "idx_crashdata_state")


### PR DESCRIPTION
- Removed `geom Unsupported("geometry")` field and its `@@index([geom], type: Gist)` from `prisma/schema.prisma`
- Root cause: Prisma 7's new WASM-based `prisma-client` generator throws a `PrismaClientValidationError` (empty message body) on any `findMany()` call when an `Unsupported` type field is present in the model — diagnosed from the 10ms response time confirming the error occurred before any database query
- The `geom` column and GiST index remain intact in the database; raw spatial queries via `prisma.$queryRaw` are unaffected

Closes #87 