### PR TITLE
Build Crash Detail Popup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,11 +276,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 - [x] Add GeoJSON data layer — fetch crashes via GraphQL and render as a basic circle layer on the map using `Latitude`/`Longitude` fields
 - [x] Add severity-based circle styling — color, opacity, and size gradient per injury bucket (Death → Major → Minor → None) using Mapbox `interpolate` expressions; sizes scale with zoom
-- [ ] Add mode stroke differentiation — stroke color distinguishes bicyclists (blue `#1565C0`) vs. pedestrians (purple `#4A148C`); stroke width scales with zoom
-- [ ] Hide None/Unknown injuries by default — Mapbox layer filter excludes the None bucket on initial load
-- [ ] Add crash detail popup — click a circle to show a tooltip with date, severity, mode, location, and age group
-- [ ] Add clustering — enable `cluster: true` on the GeoJSON source; cluster circles collapse at low zoom with count labels
-- [ ] Add heatmap layer — density heatmap visible at low zoom levels, hidden as zoom increases
+- [x] Add crash detail popup — click a circle to show a tooltip with date, time, injury type, mode, location, involved persons, and collision report number (linked to WSP crash report portal)
 - [ ] Add filter state context — React Context with state + dispatch for all filters (mode, severity, date range, geo); no UI yet, just the shared state layer all filter components will consume
 - [ ] Add mode toggle filter — `ToggleGroup` in sidebar/overlay for Bicyclist / Pedestrian / All; wired to filter context
 - [ ] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
@@ -289,6 +285,9 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [ ] Load filter options on app init via `filterOptions` GraphQL query
 - [ ] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
 - [ ] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change
+- [ ] Add Key to filters panel/sheet
+- [ ] Optional: Add clustering — enable `cluster: true` on the GeoJSON source; cluster circles collapse at low zoom with count labels
+- [ ] Optional: Add heatmap layer — density heatmap visible at low zoom levels, hidden as zoom increases
 
 **Deliverables:** Working app with map and filters
 
@@ -296,7 +295,6 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 #### Milestone: Production-ready public application
 
-- [ ] Import Domain into Render settings
 - [ ] Add rate limiting middleware for public API abuse prevention
 - [ ] Configure CSP headers and CORS in Next.js
 - [ ] Add loading states, error boundaries, skeleton screens
@@ -317,6 +315,8 @@ Severity-based visual hierarchy using color, opacity, AND size:
 ### Phase 5: Iteration (Ongoing)
 
 - [ ] Gather user feedback and iterate on visualizations
+- [ ] Hide None/Unknown injuries by default — Mapbox layer filter excludes the None bucket on initial load
+- [ ] Add mode stroke differentiation — stroke color distinguishes bicyclists (blue `#1565C0`) vs. pedestrians (purple `#4A148C`); stroke width scales with zoom
 - [ ] **Stretch goal: Dashboard charts** (see Section 11) — add Recharts/D3 visualizations for severity, mode, time trends, and geographic breakdowns
 - [ ] **Stretch goal: Mobile bottom sheet** (see Section 11) — upgrade from full-screen overlay using `vaul` or `react-modal-sheet` for peek/half/full snap states
 - [ ] Add comparative analysis features (year-over-year, area comparison)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.4.0
+**Version:** 0.4.1
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,15 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-19 — Crash Detail Popup
+
+- Clicking a crash circle opens a Mapbox `Popup` with date, time, injury type (raw `MostSevereInjuryType` value), mode, city/county, involved persons, and collision report number
+- Report number links to the WSP crash report portal (`wrecr.wsp.wa.gov/wrecr/order`); opens in a new tab
+- Added `injuryType` field to GraphQL schema (`typeDefs.ts`, `resolvers.ts`, generated types) returning the raw `MostSevereInjuryType` value; severity bucket is still used for the color dot
+- Added `interactiveLayerIds` to `Map` component to enable feature-level click events; clicking empty space closes the popup
+- Used `useMap` hook in `CrashLayer` to attach `mouseenter`/`mouseleave` cursor-pointer events on the circle layer
+- Added `time`, `involvedPersons`, `city`, `county`, `injuryType` to `GET_CRASHES` query and GeoJSON feature properties
 
 ### 2026-02-19 — Style crash circles by severity and zoom
 

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -1,13 +1,43 @@
 'use client'
 
-import { forwardRef } from 'react'
-import Map from 'react-map-gl/mapbox'
+import { forwardRef, useState, useCallback } from 'react'
+import Map, { Popup } from 'react-map-gl/mapbox'
 import type { MapRef } from 'react-map-gl/mapbox'
 import { useTheme } from 'next-themes'
 import { CrashLayer } from './CrashLayer'
 
 const DESKTOP_VIEW = { longitude: -120.9, latitude: 47.32, zoom: 6.9 }
 const MOBILE_VIEW = { longitude: -122.336, latitude: 47.6062, zoom: 10.25 }
+
+type SelectedCrash = {
+  longitude: number
+  latitude: number
+  colliRptNum: string | null
+  severity: string | null
+  injuryType: string | null
+  mode: string | null
+  crashDate: string | null
+  time: string | null
+  involvedPersons: number | null
+  city: string | null
+  county: string | null
+}
+
+const SEVERITY_COLORS: Record<string, string> = {
+  Death: '#B71C1C',
+  'Major Injury': '#F57C00',
+  'Minor Injury': '#FDD835',
+  None: '#C5E1A5',
+}
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
 
 export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
@@ -19,6 +49,34 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
       ? 'mapbox://styles/mapbox/dark-v11'
       : 'mapbox://styles/mapbox/light-v11'
 
+  const [selectedCrash, setSelectedCrash] = useState<SelectedCrash | null>(null)
+
+  const handleMapClick = useCallback(
+    (e: Parameters<NonNullable<React.ComponentProps<typeof Map>['onClick']>>[0]) => {
+      const feature = e.features?.[0]
+      if (!feature || feature.geometry.type !== 'Point') {
+        setSelectedCrash(null)
+        return
+      }
+      const coords = feature.geometry.coordinates as [number, number]
+      const p = feature.properties as Record<string, string | number | null>
+      setSelectedCrash({
+        longitude: coords[0],
+        latitude: coords[1],
+        colliRptNum: p.colliRptNum as string | null,
+        severity: p.severity as string | null,
+        injuryType: p.injuryType as string | null,
+        mode: p.mode as string | null,
+        crashDate: p.crashDate as string | null,
+        time: p.time as string | null,
+        involvedPersons: p.involvedPersons as number | null,
+        city: p.city as string | null,
+        county: p.county as string | null,
+      })
+    },
+    []
+  )
+
   return (
     <Map
       ref={ref}
@@ -26,8 +84,73 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
       initialViewState={initialViewState}
       style={{ width: '100%', height: '100%' }}
       mapStyle={mapStyle}
+      interactiveLayerIds={['crashes-circles']}
+      onClick={handleMapClick}
     >
       <CrashLayer />
+
+      {selectedCrash && (
+        <Popup
+          longitude={selectedCrash.longitude}
+          latitude={selectedCrash.latitude}
+          onClose={() => setSelectedCrash(null)}
+          closeButton
+          closeOnClick={false}
+          anchor="bottom"
+          offset={10}
+          maxWidth="220px"
+        >
+          <div style={{ padding: '6px 4px', fontSize: '13px', lineHeight: '1.6' }}>
+            {selectedCrash.crashDate && (
+              <div style={{ fontWeight: 600, marginBottom: '2px' }}>
+                {formatDate(selectedCrash.crashDate)}
+              </div>
+            )}
+            {selectedCrash.time && (
+              <div style={{ color: '#666', marginBottom: '4px' }}>{selectedCrash.time}</div>
+            )}
+            {(selectedCrash.severity || selectedCrash.injuryType) && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                <span
+                  style={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: '50%',
+                    backgroundColor: selectedCrash.severity
+                      ? (SEVERITY_COLORS[selectedCrash.severity] ?? '#999')
+                      : '#999',
+                    flexShrink: 0,
+                    border: '1px solid rgba(0,0,0,0.15)',
+                  }}
+                />
+                {selectedCrash.injuryType ?? selectedCrash.severity}
+              </div>
+            )}
+            {selectedCrash.mode && <div>{selectedCrash.mode}</div>}
+            {(selectedCrash.city || selectedCrash.county) && (
+              <div style={{ color: '#666' }}>
+                {[selectedCrash.city, selectedCrash.county].filter(Boolean).join(', ')}
+              </div>
+            )}
+            {selectedCrash.involvedPersons != null && (
+              <div style={{ color: '#666' }}>{selectedCrash.involvedPersons} involved</div>
+            )}
+            {selectedCrash.colliRptNum && (
+              <div style={{ color: '#999', fontSize: '11px', marginTop: '4px' }}>
+                Report #:{' '}
+                <a
+                  href="https://wrecr.wsp.wa.gov/wrecr/order"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: '#999', textDecoration: 'underline' }}
+                >
+                  {selectedCrash.colliRptNum}
+                </a>
+              </div>
+            )}
+          </div>
+        </Popup>
+      )}
     </Map>
   )
 })

--- a/lib/graphql/__generated__/types.ts
+++ b/lib/graphql/__generated__/types.ts
@@ -44,6 +44,7 @@ export type Crash = {
   county?: Maybe<Scalars['String']['output']>
   crashDate?: Maybe<Scalars['String']['output']>
   date?: Maybe<Scalars['String']['output']>
+  injuryType?: Maybe<Scalars['String']['output']>
   involvedPersons?: Maybe<Scalars['Int']['output']>
   jurisdiction?: Maybe<Scalars['String']['output']>
   latitude?: Maybe<Scalars['Float']['output']>
@@ -289,6 +290,7 @@ export type CrashResolvers<
   county?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   crashDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  injuryType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   involvedPersons?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   jurisdiction?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -8,8 +8,13 @@ export const GET_CRASHES = gql`
         latitude
         longitude
         severity
+        injuryType
         mode
         crashDate
+        time
+        involvedPersons
+        city
+        county
       }
       totalCount
     }

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -164,6 +164,7 @@ export const resolvers: Resolvers = {
     date: (parent) => parent.fullDate,
     time: (parent) => parent.fullTime,
     severity: (parent) => rawToBucket(parent.mostSevereInjuryType),
+    injuryType: (parent) => parent.mostSevereInjuryType,
     // crashDate is a Date object from Prisma — format as YYYY-MM-DD string.
     crashDate: (parent) => parent.crashDate?.toISOString().slice(0, 10) ?? null,
   },

--- a/lib/graphql/typeDefs.ts
+++ b/lib/graphql/typeDefs.ts
@@ -12,6 +12,7 @@ export const typeDefs = `#graphql
     crashDate: String   # Proper DATE column (YYYY-MM-DD)
     time: String
     severity: String    # Mapped display bucket: Death | Major Injury | Minor Injury | None
+    injuryType: String  # Raw MostSevereInjuryType value from the database
     ageGroup: String
     involvedPersons: Int
     latitude: Float


### PR DESCRIPTION
- Clicking a crash circle opens a Mapbox `Popup` with date, time, injury type (raw `MostSevereInjuryType` value), mode, city/county, involved persons, and collision report number
- Report number links to the WSP crash report portal (`wrecr.wsp.wa.gov/wrecr/order`); opens in a new tab
- Added `injuryType` field to GraphQL schema (`typeDefs.ts`, `resolvers.ts`, generated types) returning the raw `MostSevereInjuryType` value; severity bucket is still used for the color dot
- Added `interactiveLayerIds` to `Map` component to enable feature-level click events; clicking empty space closes the popup
- Used `useMap` hook in `CrashLayer` to attach `mouseenter`/`mouseleave` cursor-pointer events on the circle layer
- Added `time`, `involvedPersons`, `city`, `county`, `injuryType` to `GET_CRASHES` query and GeoJSON feature properties

Closes #73 