### PR TITLE
Filter State Context & Crash Detail Popup Dark Mode Fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - `vitest.config.ts` — Vitest configuration with `@` path alias
 - `components/theme-provider.tsx` — thin `NextThemesProvider` wrapper (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
 - `components/ui/theme-toggle.tsx` — Sun/Moon icon button; CSS-driven icon swap via `dark:hidden`/`hidden dark:block`
+- `context/FilterContext.tsx` — React `useReducer` filter state; `FilterProvider`, `useFilterContext()`, `toCrashFilter()`, `getActiveFilterLabels()`
 - `components/layout/AppShell.tsx` — `'use client'` layout orchestrator; owns sidebar/overlay open state, renders SummaryBar and ThemeToggle
 - `components/map/MapContainer.tsx` — `'use client'` Mapbox map filling parent container
 - `components/sidebar/Sidebar.tsx` — Sheet-based right panel (desktop, ≥768px)
@@ -277,7 +278,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Add GeoJSON data layer — fetch crashes via GraphQL and render as a basic circle layer on the map using `Latitude`/`Longitude` fields
 - [x] Add severity-based circle styling — color, opacity, and size gradient per injury bucket (Death → Major → Minor → None) using Mapbox `interpolate` expressions; sizes scale with zoom
 - [x] Add crash detail popup — click a circle to show a tooltip with date, time, injury type, mode, location, involved persons, and collision report number (linked to WSP crash report portal)
-- [ ] Add filter state context — React Context with state + dispatch for all filters (mode, severity, date range, geo); no UI yet, just the shared state layer all filter components will consume
+- [x] Add filter state context — React Context with state + dispatch for all filters (mode, severity, date range, geo); `CrashLayer` query and `SummaryBar` count now driven by filter state
 - [ ] Add mode toggle filter — `ToggleGroup` in sidebar/overlay for Bicyclist / Pedestrian / All; wired to filter context
 - [ ] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
 - [ ] Add date range quick-select — four year buttons (most recent 4 years) that set the date filter in context

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.4.1
+**Version:** 0.4.2
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,19 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-19 — Filter State Context
+
+- Created `context/FilterContext.tsx` — React `useReducer`-based filter state for all filter dimensions: mode (`Bicyclist`/`Pedestrian`/`null`), severity buckets (`Death`, `Major Injury`, `Minor Injury`), no-injury opt-in, date (year shortcut or custom range), and geographic cascading dropdowns (state → county → city)
+- Cascading resets baked into the reducer: selecting a new state clears county and city; selecting a new county clears city
+- `FilterProvider` wraps children in `app/layout.tsx`; `useFilterContext()` hook provides typed access to state and dispatch throughout the component tree
+- `toCrashFilter()` helper converts `FilterState` → `CrashFilter` GraphQL input object; `getActiveFilterLabels()` derives human-readable badge strings for non-default active filters
+- `CrashLayer` now reads filter state from context and passes it to the `GET_CRASHES` query; dispatches `SET_TOTAL_COUNT` after each query so `AppShell` can pass the live crash count to `SummaryBar`
+
+### 2026-02-19 — Crash Detail Popup — Dark Mode
+
+- Popup container dark mode override added to `globals.css` (`.dark .mapboxgl-popup-content`) — required `!important` to win the cascade against mapbox-gl's own stylesheet loaded via `layout.tsx`; popup arrow tip (`anchor-bottom`) and close button also themed
+- Popup content muted text switched from Tailwind `text-muted-foreground` class to inline `style={{ color: 'var(--muted-foreground)' }}` — Tailwind v4 `@theme inline` may compile color utility classes as static values rather than live CSS variable references; direct inline CSS `var()` references update reliably when the `.dark` class toggles on `<html>`
 
 ### 2026-02-19 — Crash Detail Popup
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -124,3 +124,27 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ── Mapbox popup dark mode overrides ─────────────────────────────────────── */
+/* The Popup component renders outside React's style scope, so Tailwind classes
+   on inner divs won't affect the container shell. Override it via global CSS. */
+
+.dark .mapboxgl-popup-content {
+  background: var(--card) !important;
+  color: var(--card-foreground) !important;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+/* Arrow for anchor="bottom" — the tip uses border-top-color for its fill */
+.dark .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip {
+  border-top-color: var(--card) !important;
+}
+
+.dark .mapboxgl-popup-close-button {
+  color: var(--muted-foreground);
+}
+
+.dark .mapboxgl-popup-close-button:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { ApolloProvider } from './apollo-provider'
 import { ThemeProvider } from '@/components/theme-provider'
+import { FilterProvider } from '@/context/FilterContext'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './globals.css'
 
@@ -34,7 +35,9 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <ApolloProvider>{children}</ApolloProvider>
+          <ApolloProvider>
+            <FilterProvider>{children}</FilterProvider>
+          </ApolloProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -9,11 +9,13 @@ import { FilterOverlay } from '@/components/overlay/FilterOverlay'
 import { SummaryBar } from '@/components/summary/SummaryBar'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { useFilterContext, getActiveFilterLabels } from '@/context/FilterContext'
 
 export function AppShell() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [overlayOpen, setOverlayOpen] = useState(false)
   const mapRef = useRef<MapRef>(null)
+  const { filterState } = useFilterContext()
 
   // Call resize() after sidebar/overlay transitions so Mapbox recomputes canvas size.
   // 300ms matches the shadcn Sheet slide animation duration.
@@ -53,7 +55,10 @@ export function AppShell() {
         </div>
       </div>
 
-      <SummaryBar />
+      <SummaryBar
+        crashCount={filterState.totalCount}
+        activeFilters={getActiveFilterLabels(filterState)}
+      />
 
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       <FilterOverlay isOpen={overlayOpen} onClose={() => setOverlayOpen(false)} />

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -6,6 +6,7 @@ import { Source, Layer, useMap } from 'react-map-gl/mapbox'
 import type { LayerProps } from 'react-map-gl/mapbox'
 import type { FeatureCollection, Point } from 'geojson'
 import { GET_CRASHES } from '@/lib/graphql/queries'
+import { useFilterContext, toCrashFilter } from '@/context/FilterContext'
 
 type CrashItem = {
   colliRptNum: string
@@ -114,9 +115,15 @@ const circleLayer: LayerProps = {
 
 export function CrashLayer() {
   const { current: map } = useMap()
+  const { filterState, dispatch } = useFilterContext()
   const { data, error } = useQuery<GetCrashesQuery>(GET_CRASHES, {
-    variables: { limit: 5000 },
+    variables: { filter: toCrashFilter(filterState), limit: 5000 },
   })
+
+  // Surface the true total count to the filter context so SummaryBar can display it.
+  useEffect(() => {
+    dispatch({ type: 'SET_TOTAL_COUNT', payload: data?.crashes.totalCount ?? null })
+  }, [data, dispatch])
 
   useEffect(() => {
     if (!map) return

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -100,17 +100,17 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
           offset={10}
           maxWidth="220px"
         >
-          <div style={{ padding: '6px 4px', fontSize: '13px', lineHeight: '1.6' }}>
+          <div className="px-1 py-1.5 text-[13px] leading-relaxed">
             {selectedCrash.crashDate && (
-              <div style={{ fontWeight: 600, marginBottom: '2px' }}>
-                {formatDate(selectedCrash.crashDate)}
-              </div>
+              <div className="mb-0.5 font-semibold">{formatDate(selectedCrash.crashDate)}</div>
             )}
             {selectedCrash.time && (
-              <div style={{ color: '#666', marginBottom: '4px' }}>{selectedCrash.time}</div>
+              <div className="mb-1" style={{ color: 'var(--muted-foreground)' }}>
+                {selectedCrash.time}
+              </div>
             )}
             {(selectedCrash.severity || selectedCrash.injuryType) && (
-              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+              <div className="flex items-center gap-1.5">
                 <span
                   style={{
                     width: 10,
@@ -128,21 +128,23 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
             )}
             {selectedCrash.mode && <div>{selectedCrash.mode}</div>}
             {(selectedCrash.city || selectedCrash.county) && (
-              <div style={{ color: '#666' }}>
+              <div style={{ color: 'var(--muted-foreground)' }}>
                 {[selectedCrash.city, selectedCrash.county].filter(Boolean).join(', ')}
               </div>
             )}
             {selectedCrash.involvedPersons != null && (
-              <div style={{ color: '#666' }}>{selectedCrash.involvedPersons} involved</div>
+              <div style={{ color: 'var(--muted-foreground)' }}>
+                {selectedCrash.involvedPersons} involved
+              </div>
             )}
             {selectedCrash.colliRptNum && (
-              <div style={{ color: '#999', fontSize: '11px', marginTop: '4px' }}>
+              <div className="mt-1 text-[11px]" style={{ color: 'var(--muted-foreground)' }}>
                 Report #:{' '}
                 <a
                   href="https://wrecr.wsp.wa.gov/wrecr/order"
                   target="_blank"
                   rel="noopener noreferrer"
-                  style={{ color: '#999', textDecoration: 'underline' }}
+                  style={{ color: 'var(--muted-foreground)', textDecoration: 'underline' }}
                 >
                   {selectedCrash.colliRptNum}
                 </a>

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { createContext, useContext, useReducer, type ReactNode } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type SeverityBucket = 'Death' | 'Major Injury' | 'Minor Injury' | 'None'
+export type ModeFilter = 'Bicyclist' | 'Pedestrian' | null
+
+export type DateFilter =
+  | { type: 'none' }
+  | { type: 'year'; year: number }
+  | { type: 'range'; startDate: string; endDate: string }
+
+export interface FilterState {
+  mode: ModeFilter
+  severity: SeverityBucket[]
+  includeNoInjury: boolean
+  dateFilter: DateFilter
+  state: string | null // geographic state (e.g. "Washington")
+  county: string | null
+  city: string | null
+  totalCount: number | null // populated by CrashLayer after query
+}
+
+export type FilterAction =
+  | { type: 'SET_MODE'; payload: ModeFilter }
+  | { type: 'SET_SEVERITY'; payload: SeverityBucket[] }
+  | { type: 'TOGGLE_NO_INJURY' }
+  | { type: 'SET_DATE_YEAR'; payload: number }
+  | { type: 'SET_DATE_RANGE'; payload: { startDate: string; endDate: string } }
+  | { type: 'CLEAR_DATE' }
+  | { type: 'SET_STATE'; payload: string | null }
+  | { type: 'SET_COUNTY'; payload: string | null }
+  | { type: 'SET_CITY'; payload: string | null }
+  | { type: 'SET_TOTAL_COUNT'; payload: number | null }
+  | { type: 'RESET' }
+
+// Matches the CrashFilter GraphQL input shape (used as Apollo query variables).
+export type CrashFilterInput = {
+  severity?: string[]
+  mode?: string
+  state?: string
+  county?: string
+  city?: string
+  dateFrom?: string
+  dateTo?: string
+  year?: number
+  includeNoInjury?: boolean
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const DEFAULT_SEVERITY: SeverityBucket[] = ['Death', 'Major Injury', 'Minor Injury']
+
+const initialState: FilterState = {
+  mode: null,
+  severity: DEFAULT_SEVERITY,
+  includeNoInjury: false,
+  dateFilter: { type: 'none' },
+  state: null,
+  county: null,
+  city: null,
+  totalCount: null,
+}
+
+// ── Reducer ───────────────────────────────────────────────────────────────────
+
+function filterReducer(filterState: FilterState, action: FilterAction): FilterState {
+  switch (action.type) {
+    case 'SET_MODE':
+      return { ...filterState, mode: action.payload }
+    case 'SET_SEVERITY':
+      return { ...filterState, severity: action.payload }
+    case 'TOGGLE_NO_INJURY':
+      return { ...filterState, includeNoInjury: !filterState.includeNoInjury }
+    case 'SET_DATE_YEAR':
+      return { ...filterState, dateFilter: { type: 'year', year: action.payload } }
+    case 'SET_DATE_RANGE':
+      return {
+        ...filterState,
+        dateFilter: {
+          type: 'range',
+          startDate: action.payload.startDate,
+          endDate: action.payload.endDate,
+        },
+      }
+    case 'CLEAR_DATE':
+      return { ...filterState, dateFilter: { type: 'none' } }
+    // Cascading: selecting a new state resets county and city.
+    case 'SET_STATE':
+      return { ...filterState, state: action.payload, county: null, city: null }
+    // Cascading: selecting a new county resets city.
+    case 'SET_COUNTY':
+      return { ...filterState, county: action.payload, city: null }
+    case 'SET_CITY':
+      return { ...filterState, city: action.payload }
+    case 'SET_TOTAL_COUNT':
+      return { ...filterState, totalCount: action.payload }
+    case 'RESET':
+      return initialState
+    default:
+      return filterState
+  }
+}
+
+// ── Context ───────────────────────────────────────────────────────────────────
+
+type FilterContextValue = {
+  filterState: FilterState
+  dispatch: React.Dispatch<FilterAction>
+}
+
+const FilterContext = createContext<FilterContextValue | null>(null)
+
+export function FilterProvider({ children }: { children: ReactNode }) {
+  const [filterState, dispatch] = useReducer(filterReducer, initialState)
+  return (
+    <FilterContext.Provider value={{ filterState, dispatch }}>{children}</FilterContext.Provider>
+  )
+}
+
+export function useFilterContext(): FilterContextValue {
+  const ctx = useContext(FilterContext)
+  if (!ctx) throw new Error('useFilterContext must be used within FilterProvider')
+  return ctx
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Convert FilterState to CrashFilter GraphQL input variables.
+ * Pass this directly as the `filter` variable to Apollo queries.
+ */
+export function toCrashFilter(filterState: FilterState): CrashFilterInput {
+  const effectiveSeverity: string[] = [
+    ...filterState.severity,
+    ...(filterState.includeNoInjury ? ['None'] : []),
+  ]
+
+  const dateVars =
+    filterState.dateFilter.type === 'year'
+      ? { year: filterState.dateFilter.year }
+      : filterState.dateFilter.type === 'range'
+        ? { dateFrom: filterState.dateFilter.startDate, dateTo: filterState.dateFilter.endDate }
+        : {}
+
+  return {
+    severity: effectiveSeverity,
+    ...(filterState.mode ? { mode: filterState.mode } : {}),
+    ...(filterState.state ? { state: filterState.state } : {}),
+    ...(filterState.county ? { county: filterState.county } : {}),
+    ...(filterState.city ? { city: filterState.city } : {}),
+    ...dateVars,
+    includeNoInjury: filterState.includeNoInjury,
+  }
+}
+
+/**
+ * Derive human-readable badge labels for all active (non-default) filters.
+ * Used by SummaryBar to render active filter chips.
+ */
+export function getActiveFilterLabels(filterState: FilterState): string[] {
+  const labels: string[] = []
+
+  if (filterState.mode) labels.push(filterState.mode + 's')
+
+  // Only flag severity when it differs from the default three-bucket set.
+  const defaultSet = new Set<string>(DEFAULT_SEVERITY)
+  const currentSet = new Set<string>(filterState.severity)
+  const severityChanged =
+    filterState.severity.some((s) => !defaultSet.has(s)) ||
+    DEFAULT_SEVERITY.some((s) => !currentSet.has(s)) ||
+    filterState.includeNoInjury
+
+  if (severityChanged) {
+    const all = [...filterState.severity, ...(filterState.includeNoInjury ? ['None'] : [])]
+    labels.push(all.length === 0 ? 'No severity' : all.join(' + '))
+  }
+
+  if (filterState.dateFilter.type === 'year') {
+    labels.push(String(filterState.dateFilter.year))
+  } else if (filterState.dateFilter.type === 'range') {
+    labels.push(`${filterState.dateFilter.startDate} – ${filterState.dateFilter.endDate}`)
+  }
+
+  if (filterState.state) labels.push(filterState.state)
+  if (filterState.county) labels.push(filterState.county)
+  if (filterState.city) labels.push(filterState.city)
+
+  return labels
+}


### PR DESCRIPTION
Filter State Context

- Created `context/FilterContext.tsx` — React `useReducer`-based filter state for all filter dimensions: mode (`Bicyclist`/`Pedestrian`/`null`), severity buckets (`Death`, `Major Injury`, `Minor Injury`), no-injury opt-in, date (year shortcut or custom range), and geographic cascading dropdowns (state → county → city)
- Cascading resets baked into the reducer: selecting a new state clears county and city; selecting a new county clears city
- `FilterProvider` wraps children in `app/layout.tsx`; `useFilterContext()` hook provides typed access to state and dispatch throughout the component tree
- `toCrashFilter()` helper converts `FilterState` → `CrashFilter` GraphQL input object; `getActiveFilterLabels()` derives human-readable badge strings for non-default active filters
- `CrashLayer` now reads filter state from context and passes it to the `GET_CRASHES` query; dispatches `SET_TOTAL_COUNT` after each query so `AppShell` can pass the live crash count to `SummaryBar`

Closes #76 

Crash Detail Popup — Dark Mode
- Popup container dark mode override added to `globals.css` (`.dark .mapboxgl-popup-content`) — required `!important` to win the cascade against mapbox-gl's own stylesheet loaded via `layout.tsx`; popup arrow tip (`anchor-bottom`) and close button also themed
- Popup content muted text switched from Tailwind `text-muted-foreground` class to inline `style={{ color: 'var(--muted-foreground)' }}` — Tailwind v4 `@theme inline` may compile color utility classes as static values rather than live CSS variable references; direct inline CSS `var()` references update reliably when the `.dark` class toggles on `<html>`

Closes #91 