### PR TITLE
Add Mode Toggle Filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,13 +273,18 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Set default zoom for mobile to the city of Seattle
 - [x] Light/Dark mode — `next-themes` provider, Sun/Moon toggle button, dynamic Mapbox style swap (`light-v11` ↔ `dark-v11`)
 
-#### Milestone: Interactive map with filters
+### Phase 4: Interactive filters
+
+#### Milestone: Prepare Data and Context for Filters
 
 - [x] Add GeoJSON data layer — fetch crashes via GraphQL and render as a basic circle layer on the map using `Latitude`/`Longitude` fields
 - [x] Add severity-based circle styling — color, opacity, and size gradient per injury bucket (Death → Major → Minor → None) using Mapbox `interpolate` expressions; sizes scale with zoom
 - [x] Add crash detail popup — click a circle to show a tooltip with date, time, injury type, mode, location, involved persons, and collision report number (linked to WSP crash report portal)
 - [x] Add filter state context — React Context with state + dispatch for all filters (mode, severity, date range, geo); `CrashLayer` query and `SummaryBar` count now driven by filter state
-- [ ] Add mode toggle filter — `ToggleGroup` in sidebar/overlay for Bicyclist / Pedestrian / All; wired to filter context
+
+#### Milestone: Implement Filtering UI
+
+- [x] Add mode toggle filter — `ToggleGroup` in sidebar/overlay for Bicyclist / Pedestrian / All; wired to filter context
 - [ ] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
 - [ ] Add date range quick-select — four year buttons (most recent 4 years) that set the date filter in context
 - [ ] Add date range custom picker — `Popover` + `Calendar` for arbitrary start/end date selection; shares the same date filter state as quick-select buttons
@@ -287,12 +292,15 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [ ] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
 - [ ] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change
 - [ ] Add Key to filters panel/sheet
+
+#### Milestone: Optional UI
+
 - [ ] Optional: Add clustering — enable `cluster: true` on the GeoJSON source; cluster circles collapse at low zoom with count labels
 - [ ] Optional: Add heatmap layer — density heatmap visible at low zoom levels, hidden as zoom increases
 
 **Deliverables:** Working app with map and filters
 
-### Phase 4: Security, Polish & Deployment (Weeks TBD)
+### Phase 5: Security, Polish & Deployment (Weeks TBD)
 
 #### Milestone: Production-ready public application
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.4.2
+**Version:** 0.5.0
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-19 — Mode Toggle Filter
+
+- Created `components/filters/ModeToggle.tsx` — shared `ToggleGroup` component with three items: **All** / **Bicyclist** / **Pedestrian**; maps `null` (all modes) ↔ the `"all"` string for Radix ToggleGroup's value prop; ignores empty-string deselection events so exactly one item is always active
+- Added `ModeToggle` to `Sidebar` (desktop) and `FilterOverlay` (mobile), replacing the placeholder text in both; filter state is shared via `useFilterContext()` so both surfaces stay in sync
+- Dispatches `SET_MODE` to `FilterContext`; `toCrashFilter()` already maps `mode` to the GraphQL `CrashFilter` input, so the map updates automatically on selection change
 
 ### 2026-02-19 — Filter State Context
 

--- a/components/filters/ModeToggle.tsx
+++ b/components/filters/ModeToggle.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { useFilterContext, type ModeFilter } from '@/context/FilterContext'
+
+export function ModeToggle() {
+  const { filterState, dispatch } = useFilterContext()
+
+  const value = filterState.mode ?? 'all'
+
+  function handleChange(newValue: string) {
+    // Ignore deselection clicks (Radix fires "" when the active item is clicked again).
+    if (!newValue) return
+    dispatch({
+      type: 'SET_MODE',
+      payload: newValue === 'all' ? null : (newValue as ModeFilter),
+    })
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Mode</p>
+      <ToggleGroup type="single" variant="outline" value={value} onValueChange={handleChange}>
+        <ToggleGroupItem value="all" aria-label="All modes">
+          All
+        </ToggleGroupItem>
+        <ToggleGroupItem value="Bicyclist" aria-label="Bicyclists only">
+          Bicyclist
+        </ToggleGroupItem>
+        <ToggleGroupItem value="Pedestrian" aria-label="Pedestrians only">
+          Pedestrian
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  )
+}

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ModeToggle } from '@/components/filters/ModeToggle'
 
 interface FilterOverlayProps {
   isOpen: boolean
@@ -25,8 +26,8 @@ export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
         </Button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 py-4">
-        <p className="text-sm text-muted-foreground">Filter controls coming soon.</p>
+      <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
+        <ModeToggle />
       </div>
     </div>
   )

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { ModeToggle } from '@/components/filters/ModeToggle'
 
 interface SidebarProps {
   isOpen: boolean
@@ -12,8 +13,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         <SheetHeader>
           <SheetTitle>Filters</SheetTitle>
         </SheetHeader>
-        <div className="px-4 pb-4">
-          <p className="text-sm text-muted-foreground">Filter controls coming soon.</p>
+        <div className="space-y-6 px-4 pb-4">
+          <ModeToggle />
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
- Created `components/filters/ModeToggle.tsx` — shared `ToggleGroup` component with three items: **All** / **Bicyclist** / **Pedestrian**; maps `null` (all modes) ↔ the `"all"` string for Radix ToggleGroup's value prop; ignores empty-string deselection events so exactly one item is always active
- Added `ModeToggle` to `Sidebar` (desktop) and `FilterOverlay` (mobile), replacing the placeholder text in both; filter state is shared via `useFilterContext()` so both surfaces stay in sync
- Dispatches `SET_MODE` to `FilterContext`; `toCrashFilter()` already maps `mode` to the GraphQL `CrashFilter` input, so the map updates automatically on selection change

Closes #77 