### PR TITLE
Add Severity Multi-Select Filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 #### Milestone: Implement Filtering UI
 
 - [x] Add mode toggle filter — `ToggleGroup` in sidebar/overlay for Bicyclist / Pedestrian / All; wired to filter context
-- [ ] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
+- [x] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
 - [ ] Add date range quick-select — four year buttons (most recent 4 years) that set the date filter in context
 - [ ] Add date range custom picker — `Popover` + `Calendar` for arbitrary start/end date selection; shares the same date filter state as quick-select buttons
 - [ ] Load filter options on app init via `filterOptions` GraphQL query

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.5.0
+**Version:** 0.6.0
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-19 — Severity Multi-Select Filter
+
+- Created `components/filters/SeverityFilter.tsx` — three checkboxes for Death, Major Injury, Minor Injury (all checked by default) plus a separate opt-in "No Injury / Unknown" checkbox below a divider; each row includes a colored dot matching the corresponding Mapbox circle color
+- `toggleBucket()` builds a new `SeverityBucket[]` array and dispatches `SET_SEVERITY`; the None opt-in dispatches `TOGGLE_NO_INJURY` (handled separately in the reducer)
+- Added `SeverityFilter` to `Sidebar` and `FilterOverlay`; `toCrashFilter()` merges both `severity` and `includeNoInjury` into `effectiveSeverity` before passing to the GraphQL query
 
 ### 2026-02-19 — Mode Toggle Filter
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.6.0
+**Version:** 0.4.3
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 

--- a/components/filters/SeverityFilter.tsx
+++ b/components/filters/SeverityFilter.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { Checkbox } from '@/components/ui/checkbox'
+import { useFilterContext, type SeverityBucket } from '@/context/FilterContext'
+
+// Colors match the circle layer styling in CrashLayer.tsx.
+const SEVERITY_COLORS: Record<SeverityBucket | 'None', string> = {
+  Death: '#B71C1C',
+  'Major Injury': '#E65100',
+  'Minor Injury': '#F9A825',
+  None: '#C5E1A5',
+}
+
+const BUCKETS: SeverityBucket[] = ['Death', 'Major Injury', 'Minor Injury']
+
+export function SeverityFilter() {
+  const { filterState, dispatch } = useFilterContext()
+
+  function toggleBucket(bucket: SeverityBucket, checked: boolean) {
+    const next = checked
+      ? [...filterState.severity, bucket]
+      : filterState.severity.filter((b) => b !== bucket)
+    dispatch({ type: 'SET_SEVERITY', payload: next })
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Severity</p>
+
+      <div className="space-y-2">
+        {BUCKETS.map((bucket) => (
+          <div key={bucket} className="flex items-center gap-2">
+            <Checkbox
+              id={`severity-${bucket}`}
+              checked={filterState.severity.includes(bucket)}
+              onCheckedChange={(checked) => toggleBucket(bucket, checked === true)}
+            />
+            <span
+              className="size-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: SEVERITY_COLORS[bucket] }}
+              aria-hidden="true"
+            />
+            <label htmlFor={`severity-${bucket}`} className="cursor-pointer text-sm leading-none">
+              {bucket}
+            </label>
+          </div>
+        ))}
+      </div>
+
+      <div className="border-t pt-2">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="severity-none"
+            checked={filterState.includeNoInjury}
+            onCheckedChange={() => dispatch({ type: 'TOGGLE_NO_INJURY' })}
+          />
+          <span
+            className="size-2.5 shrink-0 rounded-full"
+            style={{ backgroundColor: SEVERITY_COLORS['None'] }}
+            aria-hidden="true"
+          />
+          <label htmlFor="severity-none" className="cursor-pointer text-sm leading-none">
+            No Injury / Unknown
+          </label>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -3,6 +3,7 @@
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ModeToggle } from '@/components/filters/ModeToggle'
+import { SeverityFilter } from '@/components/filters/SeverityFilter'
 
 interface FilterOverlayProps {
   isOpen: boolean
@@ -28,6 +29,7 @@ export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
 
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
         <ModeToggle />
+        <SeverityFilter />
       </div>
     </div>
   )

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { ModeToggle } from '@/components/filters/ModeToggle'
+import { SeverityFilter } from '@/components/filters/SeverityFilter'
 
 interface SidebarProps {
   isOpen: boolean
@@ -15,6 +16,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         </SheetHeader>
         <div className="space-y-6 px-4 pb-4">
           <ModeToggle />
+          <SeverityFilter />
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
- Created `components/filters/SeverityFilter.tsx` — three checkboxes for Death, Major Injury, Minor Injury (all checked by default) plus a separate opt-in "No Injury / Unknown" checkbox below a divider; each row includes a colored dot matching the corresponding Mapbox circle color
- `toggleBucket()` builds a new `SeverityBucket[]` array and dispatches `SET_SEVERITY`; the None opt-in dispatches `TOGGLE_NO_INJURY` (handled separately in the reducer)
- Added `SeverityFilter` to `Sidebar` and `FilterOverlay`; `toCrashFilter()` merges both `severity` and `includeNoInjury` into `effectiveSeverity` before passing to the GraphQL query

Closes #78 