### PR TITLE
Added Date Filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,8 +286,8 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 - [x] Add mode toggle filter — `ToggleGroup` in sidebar/overlay for Bicyclist / Pedestrian / All; wired to filter context
 - [x] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
-- [ ] Add date range quick-select — four year buttons (most recent 4 years) that set the date filter in context
-- [ ] Add date range custom picker — `Popover` + `Calendar` for arbitrary start/end date selection; shares the same date filter state as quick-select buttons
+- [x] Add date range quick-select — four year buttons (most recent 4 years) that set the date filter in context
+- [x] Add date range custom picker — `Popover` + `Calendar` for arbitrary start/end date selection; shares the same date filter state as quick-select buttons
 - [ ] Load filter options on app init via `filterOptions` GraphQL query
 - [ ] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
 - [ ] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — Date Filter (Year Quick-Select + Custom Range Picker)
+
+- Created `components/filters/DateFilter.tsx` — four year quick-select buttons (most recent 4 years, derived from `new Date().getFullYear()` at runtime); clicking the active year deselects it (`CLEAR_DATE`); clicking a new year dispatches `SET_DATE_YEAR`
+- Added a "Custom range…" Popover + Calendar button below the year buttons; uses `react-day-picker` `mode="range"` to capture a start and end date with two clicks; dispatches `SET_DATE_RANGE` only when both ends are selected, then auto-closes
+- `pendingRange` local state tracks in-progress calendar clicks without prematurely writing to context; reset if the popover is closed before a full range is chosen
+- "Clear dates" footer appears inside the popover when a range is committed; dispatches `CLEAR_DATE`
+- Year buttons and the custom range share the same `dateFilter` slot in `FilterContext` — selecting one implicitly clears the other
+- Added `DateFilter` to `Sidebar` and `FilterOverlay` between Mode and Severity sections
+
 ### 2026-02-19 — Severity Multi-Select Filter
 
 - Created `components/filters/SeverityFilter.tsx` — three checkboxes for Death, Major Injury, Minor Injury (all checked by default) plus a separate opt-in "No Injury / Unknown" checkbox below a divider; each row includes a colored dot matching the corresponding Mapbox circle color

--- a/components/filters/DateFilter.tsx
+++ b/components/filters/DateFilter.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useState } from 'react'
+import { format, parseISO } from 'date-fns'
+import type { DateRange } from 'react-day-picker'
+import { CalendarIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useFilterContext } from '@/context/FilterContext'
+
+const CURRENT_YEAR = new Date().getFullYear()
+const QUICK_YEARS = [CURRENT_YEAR - 1, CURRENT_YEAR - 2, CURRENT_YEAR - 3, CURRENT_YEAR - 4]
+
+export function DateFilter() {
+  const { filterState, dispatch } = useFilterContext()
+  const [open, setOpen] = useState(false)
+  // Tracks the in-progress selection inside the popover before both dates are chosen.
+  const [pendingRange, setPendingRange] = useState<DateRange | undefined>()
+
+  const selectedYear = filterState.dateFilter.type === 'year' ? filterState.dateFilter.year : null
+  const selectedRange = filterState.dateFilter.type === 'range' ? filterState.dateFilter : null
+
+  function handleYearClick(year: number) {
+    if (selectedYear === year) {
+      dispatch({ type: 'CLEAR_DATE' })
+    } else {
+      dispatch({ type: 'SET_DATE_YEAR', payload: year })
+    }
+  }
+
+  function handleRangeSelect(range: DateRange | undefined) {
+    setPendingRange(range)
+    // Only commit once both ends are chosen.
+    if (range?.from && range?.to) {
+      dispatch({
+        type: 'SET_DATE_RANGE',
+        payload: {
+          startDate: format(range.from, 'yyyy-MM-dd'),
+          endDate: format(range.to, 'yyyy-MM-dd'),
+        },
+      })
+      setOpen(false)
+    }
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    // Discard incomplete selection when closing.
+    if (!next) setPendingRange(undefined)
+  }
+
+  // Show the committed range as the Calendar's selection; fall back to in-progress selection.
+  const calendarSelected: DateRange | undefined =
+    pendingRange ??
+    (selectedRange
+      ? { from: parseISO(selectedRange.startDate), to: parseISO(selectedRange.endDate) }
+      : undefined)
+
+  const rangeLabel = selectedRange
+    ? `${selectedRange.startDate} – ${selectedRange.endDate}`
+    : 'Custom range…'
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Date</p>
+
+      <div className="flex flex-wrap gap-2">
+        {QUICK_YEARS.map((year) => (
+          <Button
+            key={year}
+            variant={selectedYear === year ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => handleYearClick(year)}
+            aria-pressed={selectedYear === year}
+          >
+            {year}
+          </Button>
+        ))}
+      </div>
+
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            variant={selectedRange ? 'default' : 'outline'}
+            size="sm"
+            className="w-full justify-start gap-2"
+          >
+            <CalendarIcon className="size-3.5 shrink-0" />
+            {rangeLabel}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="range"
+            selected={calendarSelected}
+            onSelect={handleRangeSelect}
+            numberOfMonths={1}
+          />
+          {selectedRange && (
+            <div className="border-t px-3 py-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full"
+                onClick={() => {
+                  dispatch({ type: 'CLEAR_DATE' })
+                  setPendingRange(undefined)
+                  setOpen(false)
+                }}
+              >
+                Clear dates
+              </Button>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ModeToggle } from '@/components/filters/ModeToggle'
 import { SeverityFilter } from '@/components/filters/SeverityFilter'
+import { DateFilter } from '@/components/filters/DateFilter'
 
 interface FilterOverlayProps {
   isOpen: boolean
@@ -29,6 +30,7 @@ export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
 
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
         <ModeToggle />
+        <DateFilter />
         <SeverityFilter />
       </div>
     </div>

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { ModeToggle } from '@/components/filters/ModeToggle'
 import { SeverityFilter } from '@/components/filters/SeverityFilter'
+import { DateFilter } from '@/components/filters/DateFilter'
 
 interface SidebarProps {
   isOpen: boolean
@@ -16,6 +17,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         </SheetHeader>
         <div className="space-y-6 px-4 pb-4">
           <ModeToggle />
+          <DateFilter />
           <SeverityFilter />
         </div>
       </SheetContent>


### PR DESCRIPTION
- Created `components/filters/DateFilter.tsx` — four year quick-select buttons (most recent 4 years, derived from `new Date().getFullYear()` at runtime); clicking the active year deselects it (`CLEAR_DATE`); clicking a new year dispatches `SET_DATE_YEAR`
- Added a "Custom range…" Popover + Calendar button below the year buttons; uses `react-day-picker` `mode="range"` to capture a start and end date with two clicks; dispatches `SET_DATE_RANGE` only when both ends are selected, then auto-closes
- `pendingRange` local state tracks in-progress calendar clicks without prematurely writing to context; reset if the popover is closed before a full range is chosen
- "Clear dates" footer appears inside the popover when a range is committed; dispatches `CLEAR_DATE`
- Year buttons and the custom range share the same `dateFilter` slot in `FilterContext` — selecting one implicitly clears the other
- Added `DateFilter` to `Sidebar` and `FilterOverlay` between Mode and Severity sections

Closes #79 and #80 