### PR TITLE
Add Geographic Cascading Dropdowns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,10 +288,10 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Add severity multi-select filter — `Checkbox` + `Label` for Death, Major, Minor; None/Unknown opt-in toggle; wired to filter context
 - [x] Add date range quick-select — four year buttons (most recent 4 years) that set the date filter in context
 - [x] Add date range custom picker — `Popover` + `Calendar` for arbitrary start/end date selection; shares the same date filter state as quick-select buttons
-- [ ] Load filter options on app init via `filterOptions` GraphQL query
-- [ ] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
+- [x] Load filter options on app init via `filterOptions` GraphQL query
+- [x] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
 - [ ] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change
-- [ ] Add Key to filters panel/sheet
+- [ ] Add a colors Key to filters panels
 
 #### Milestone: Optional UI
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.4.3
+**Version:** 0.4.4
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-19 — Geographic Cascading Dropdowns (State → County → City)
+
+- Added `GET_FILTER_OPTIONS`, `GET_COUNTIES`, and `GET_CITIES` query documents to `lib/graphql/queries.ts`, each with exported TypeScript result types
+- Created `components/filters/GeographicFilter.tsx` — three cascading shadcn `Select` dropdowns (State → County → City); states and years are loaded on component mount via `GET_FILTER_OPTIONS`; counties load lazily when a state is selected; cities load lazily when a county is selected (both using Apollo `skip` option); selecting a parent level resets children via existing `FilterContext` reducer cascade logic
+- Added `<GeographicFilter />` to both `Sidebar` (desktop) and `FilterOverlay` (mobile)
 
 ### 2026-02-19 — Date Filter (Year Quick-Select + Custom Range Picker)
 

--- a/components/filters/GeographicFilter.tsx
+++ b/components/filters/GeographicFilter.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useQuery } from '@apollo/client/react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useFilterContext } from '@/context/FilterContext'
+import {
+  GET_FILTER_OPTIONS,
+  GET_COUNTIES,
+  GET_CITIES,
+  type GetFilterOptionsQuery,
+  type GetCountiesQuery,
+  type GetCitiesQuery,
+} from '@/lib/graphql/queries'
+
+// Sentinel value used instead of empty string (shadcn Select doesn't support null values).
+const ALL = '__all__'
+
+export function GeographicFilter() {
+  const { filterState, dispatch } = useFilterContext()
+
+  const { data: optionsData } = useQuery<GetFilterOptionsQuery>(GET_FILTER_OPTIONS)
+
+  const { data: countiesData } = useQuery<GetCountiesQuery>(GET_COUNTIES, {
+    variables: { state: filterState.state },
+    skip: !filterState.state,
+  })
+
+  const { data: citiesData } = useQuery<GetCitiesQuery>(GET_CITIES, {
+    variables: { state: filterState.state, county: filterState.county },
+    skip: !filterState.county,
+  })
+
+  const states = optionsData?.filterOptions?.states ?? []
+  const counties = countiesData?.filterOptions?.counties ?? []
+  const cities = citiesData?.filterOptions?.cities ?? []
+
+  function handleStateChange(value: string) {
+    dispatch({ type: 'SET_STATE', payload: value === ALL ? null : value })
+  }
+
+  function handleCountyChange(value: string) {
+    dispatch({ type: 'SET_COUNTY', payload: value === ALL ? null : value })
+  }
+
+  function handleCityChange(value: string) {
+    dispatch({ type: 'SET_CITY', payload: value === ALL ? null : value })
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Location</p>
+
+      <Select value={filterState.state ?? ALL} onValueChange={handleStateChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="All states" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>All states</SelectItem>
+          {states.map((s) => (
+            <SelectItem key={s} value={s}>
+              {s}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={filterState.county ?? ALL}
+        onValueChange={handleCountyChange}
+        disabled={!filterState.state || counties.length === 0}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="All counties" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>All counties</SelectItem>
+          {counties.map((c) => (
+            <SelectItem key={c} value={c}>
+              {c}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={filterState.city ?? ALL}
+        onValueChange={handleCityChange}
+        disabled={!filterState.county || cities.length === 0}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="All cities" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>All cities</SelectItem>
+          {cities.map((c) => (
+            <SelectItem key={c} value={c}>
+              {c}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { ModeToggle } from '@/components/filters/ModeToggle'
 import { SeverityFilter } from '@/components/filters/SeverityFilter'
 import { DateFilter } from '@/components/filters/DateFilter'
+import { GeographicFilter } from '@/components/filters/GeographicFilter'
 
 interface FilterOverlayProps {
   isOpen: boolean
@@ -32,6 +33,7 @@ export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
         <ModeToggle />
         <DateFilter />
         <SeverityFilter />
+        <GeographicFilter />
       </div>
     </div>
   )

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { ModeToggle } from '@/components/filters/ModeToggle'
 import { SeverityFilter } from '@/components/filters/SeverityFilter'
 import { DateFilter } from '@/components/filters/DateFilter'
+import { GeographicFilter } from '@/components/filters/GeographicFilter'
 
 interface SidebarProps {
   isOpen: boolean
@@ -19,6 +20,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           <ModeToggle />
           <DateFilter />
           <SeverityFilter />
+          <GeographicFilter />
         </div>
       </SheetContent>
     </Sheet>

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -1,5 +1,53 @@
 import { gql } from '@apollo/client'
 
+// ── Query result types ─────────────────────────────────────────────────────────
+
+export type GetFilterOptionsQuery = {
+  filterOptions: {
+    states: string[]
+    years: number[]
+  }
+}
+
+export type GetCountiesQuery = {
+  filterOptions: {
+    counties: string[]
+  }
+}
+
+export type GetCitiesQuery = {
+  filterOptions: {
+    cities: string[]
+  }
+}
+
+// ── Query documents ────────────────────────────────────────────────────────────
+
+export const GET_FILTER_OPTIONS = gql`
+  query GetFilterOptions {
+    filterOptions {
+      states
+      years
+    }
+  }
+`
+
+export const GET_COUNTIES = gql`
+  query GetCounties($state: String) {
+    filterOptions {
+      counties(state: $state)
+    }
+  }
+`
+
+export const GET_CITIES = gql`
+  query GetCities($state: String, $county: String) {
+    filterOptions {
+      cities(state: $state, county: $county)
+    }
+  }
+`
+
 export const GET_CRASHES = gql`
   query GetCrashes($filter: CrashFilter, $limit: Int) {
     crashes(filter: $filter, limit: $limit) {


### PR DESCRIPTION
- Added `GET_FILTER_OPTIONS`, `GET_COUNTIES`, and `GET_CITIES` query documents to `lib/graphql/queries.ts`, each with exported TypeScript result types
- Created `components/filters/GeographicFilter.tsx` — three cascading shadcn `Select` dropdowns (State → County → City); states and years are loaded on component mount via `GET_FILTER_OPTIONS`; counties load lazily when a state is selected; cities load lazily when a county is selected (both using Apollo `skip` option); selecting a parent level resets children via existing `FilterContext` reducer cascade logic
- Added `<GeographicFilter />` to both `Sidebar` (desktop) and `FilterOverlay` (mobile)

Closes #81
Closes #82