### PR TITLE
Filter Loading State

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Add date range custom picker — `Popover` + `Calendar` for arbitrary start/end date selection; shares the same date filter state as quick-select buttons
 - [x] Load filter options on app init via `filterOptions` GraphQL query
 - [x] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
-- [ ] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change
+- [x] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change
 - [ ] Add a colors Key to filters panels
 
 #### Milestone: Optional UI

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — Filter Loading State
+
+- Added `isLoading: boolean` and `SET_LOADING` action to `FilterContext` (alongside the existing `totalCount` query-state field)
+- Added `notifyOnNetworkStatusChange: true` to the `GET_CRASHES` `useQuery` call in `CrashLayer`; dispatches `SET_LOADING` on each `loading` change so the SummaryBar reflects in-flight refetches
+- `SET_TOTAL_COUNT` now only dispatches when `loading` is false, keeping the previous count visible during a filter-change refetch instead of flashing `—`
+- `SummaryBar` accepts an `isLoading` prop; applies `animate-pulse` to the crash-count text while a refetch is in flight
+
+### 2026-02-19 — Dark Reader Hydration Mismatch Fix
+
+- Added `suppressHydrationWarning` to `<Sun>` and `<Moon>` in `ThemeToggle` and to both `<SlidersHorizontal>` instances in `AppShell` — the Dark Reader browser extension injects `data-darkreader-inline-stroke` attributes into SVG elements after SSR but before React hydration, causing a harmless but noisy mismatch warning; Lucide icons forward all props to the underlying `<svg>`, so the suppression lands on the correct element
+
 ### 2026-02-19 — Geographic Cascading Dropdowns (State → County → City)
 
 - Added `GET_FILTER_OPTIONS`, `GET_COUNTIES`, and `GET_CITIES` query documents to `lib/graphql/queries.ts`, each with exported TypeScript result types

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -39,7 +39,7 @@ export function AppShell() {
             onClick={() => setSidebarOpen(true)}
             aria-label="Open filters"
           >
-            <SlidersHorizontal className="size-4" />
+            <SlidersHorizontal className="size-4" suppressHydrationWarning />
           </Button>
         </div>
         {/* Filter overlay toggle — mobile only */}
@@ -50,7 +50,7 @@ export function AppShell() {
             onClick={() => setOverlayOpen(true)}
             aria-label="Open filters"
           >
-            <SlidersHorizontal className="size-4" />
+            <SlidersHorizontal className="size-4" suppressHydrationWarning />
           </Button>
         </div>
       </div>
@@ -58,6 +58,7 @@ export function AppShell() {
       <SummaryBar
         crashCount={filterState.totalCount}
         activeFilters={getActiveFilterLabels(filterState)}
+        isLoading={filterState.isLoading}
       />
 
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -116,14 +116,22 @@ const circleLayer: LayerProps = {
 export function CrashLayer() {
   const { current: map } = useMap()
   const { filterState, dispatch } = useFilterContext()
-  const { data, error } = useQuery<GetCrashesQuery>(GET_CRASHES, {
+  const { data, error, loading } = useQuery<GetCrashesQuery>(GET_CRASHES, {
     variables: { filter: toCrashFilter(filterState), limit: 5000 },
+    notifyOnNetworkStatusChange: true,
   })
+
+  // Surface loading state so SummaryBar can show a refetch indicator.
+  useEffect(() => {
+    dispatch({ type: 'SET_LOADING', payload: loading })
+  }, [loading, dispatch])
 
   // Surface the true total count to the filter context so SummaryBar can display it.
   useEffect(() => {
-    dispatch({ type: 'SET_TOTAL_COUNT', payload: data?.crashes.totalCount ?? null })
-  }, [data, dispatch])
+    if (!loading) {
+      dispatch({ type: 'SET_TOTAL_COUNT', payload: data?.crashes.totalCount ?? null })
+    }
+  }, [data, loading, dispatch])
 
   useEffect(() => {
     if (!map) return

--- a/components/summary/SummaryBar.tsx
+++ b/components/summary/SummaryBar.tsx
@@ -5,9 +5,14 @@ import { Badge } from '@/components/ui/badge'
 interface SummaryBarProps {
   crashCount?: number | null
   activeFilters?: string[]
+  isLoading?: boolean
 }
 
-export function SummaryBar({ crashCount = null, activeFilters = [] }: SummaryBarProps) {
+export function SummaryBar({
+  crashCount = null,
+  activeFilters = [],
+  isLoading = false,
+}: SummaryBarProps) {
   const countLabel = crashCount === null ? '—' : crashCount.toLocaleString()
 
   return (
@@ -17,7 +22,9 @@ export function SummaryBar({ crashCount = null, activeFilters = [] }: SummaryBar
       aria-live="polite"
       aria-label="Summary"
     >
-      <span className="text-sm font-medium tabular-nums whitespace-nowrap">
+      <span
+        className={`text-sm font-medium tabular-nums whitespace-nowrap${isLoading ? ' animate-pulse' : ''}`}
+      >
         {countLabel} crashes
       </span>
 

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -13,8 +13,8 @@ export function ThemeToggle() {
       onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
       aria-label="Toggle theme"
     >
-      <Sun className="size-4 dark:hidden" />
-      <Moon className="size-4 hidden dark:block" />
+      <Sun className="size-4 dark:hidden" suppressHydrationWarning />
+      <Moon className="size-4 hidden dark:block" suppressHydrationWarning />
     </Button>
   )
 }

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -21,6 +21,7 @@ export interface FilterState {
   county: string | null
   city: string | null
   totalCount: number | null // populated by CrashLayer after query
+  isLoading: boolean // true while a filter-triggered refetch is in flight
 }
 
 export type FilterAction =
@@ -34,6 +35,7 @@ export type FilterAction =
   | { type: 'SET_COUNTY'; payload: string | null }
   | { type: 'SET_CITY'; payload: string | null }
   | { type: 'SET_TOTAL_COUNT'; payload: number | null }
+  | { type: 'SET_LOADING'; payload: boolean }
   | { type: 'RESET' }
 
 // Matches the CrashFilter GraphQL input shape (used as Apollo query variables).
@@ -62,6 +64,7 @@ const initialState: FilterState = {
   county: null,
   city: null,
   totalCount: null,
+  isLoading: false,
 }
 
 // ── Reducer ───────────────────────────────────────────────────────────────────
@@ -97,6 +100,8 @@ function filterReducer(filterState: FilterState, action: FilterAction): FilterSt
       return { ...filterState, city: action.payload }
     case 'SET_TOTAL_COUNT':
       return { ...filterState, totalCount: action.payload }
+    case 'SET_LOADING':
+      return { ...filterState, isLoading: action.payload }
     case 'RESET':
       return initialState
     default:


### PR DESCRIPTION
- Added `isLoading: boolean` and `SET_LOADING` action to `FilterContext` (alongside the existing `totalCount` query-state field)
- Added `notifyOnNetworkStatusChange: true` to the `GET_CRASHES` `useQuery` call in `CrashLayer`; dispatches `SET_LOADING` on each `loading` change so the SummaryBar reflects in-flight refetches
- `SET_TOTAL_COUNT` now only dispatches when `loading` is false, keeping the previous count visible during a filter-change refetch instead of flashing `—`
- `SummaryBar` accepts an `isLoading` prop; applies `animate-pulse` to the crash-count text while a refetch is in flight