### PR TITLE
Add Auto-Zoom on Geographic Filter Change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,12 +291,8 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [x] Load filter options on app init via `filterOptions` GraphQL query
 - [x] Add geographic cascading dropdowns — State → County → City `Select` components populated from `filterOptions` query data; each level resets when parent changes; wired to filter context
 - [x] Connect filters to GraphQL query variables — pass filter context state into `crashes` / `crashStats` query variables so map and summary bar update on filter change
-- [ ] Add a colors Key to filters panels
-
-#### Milestone: Optional UI
-
-- [ ] Optional: Add clustering — enable `cluster: true` on the GeoJSON source; cluster circles collapse at low zoom with count labels
-- [ ] Optional: Add heatmap layer — density heatmap visible at low zoom levels, hidden as zoom increases
+- [x] Implement automatic zoom/view changes when a geographic filter is changed. The view will automatically change to match the range of crashes.
+  - **Approach:** Two-ref pattern in `CrashLayer.tsx` — `prevGeoRef` tracks prior state/county/city values; `zoomPendingRef` flags a pending zoom. Effect 1 sets the flag when geo filter changes; Effect 2 executes `map.fitBounds()` or `map.flyTo()` when fresh data arrives. Only geo filter changes trigger zoom; severity/mode/date changes do not. See ARCHITECTURE.md §4 "Map Auto-Zoom" for full details.
 
 **Deliverables:** Working app with map and filters
 
@@ -332,5 +328,6 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - [ ] Add an admin interface for uploading new crash data (protected with NextAuth.js)
 - [ ] Monitor query performance — add materialized views only if aggregation queries become slow
 - [ ] If data grows beyond 50K rows or traffic increases, revisit the caching strategy
+- [ ] Optional: Add clustering — enable `cluster: true` on the GeoJSON source; cluster circles collapse at low zoom with count labels
 
 ---

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — Auto-Zoom on Geographic Filter Change
+
+- When a State, County, or City filter is selected, the map now automatically animates to fit the bounds of matching crashes (`map.fitBounds()` with 80px padding, 800ms animation, max zoom 14)
+- Single-crash results use `map.flyTo()` at zoom 13 instead
+- Non-geographic filter changes (severity, mode, date) do not trigger auto-zoom — the user's manually panned viewport is preserved
+- Implemented via a two-ref pattern in `CrashLayer.tsx`: `prevGeoRef` tracks prior geo filter values; `zoomPendingRef` flags a pending zoom; separate effects decouple filter-change detection from data-arrival execution
+
 ### 2026-02-19 — Filter Loading State
 
 - Added `isLoading: boolean` and `SET_LOADING` action to `FilterContext` (alongside the existing `totalCount` query-state field)

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -6,7 +6,7 @@ import type { MapRef } from 'react-map-gl/mapbox'
 import { useTheme } from 'next-themes'
 import { CrashLayer } from './CrashLayer'
 
-const DESKTOP_VIEW = { longitude: -120.9, latitude: 47.32, zoom: 6.9 }
+const DESKTOP_VIEW = { longitude: -122.336, latitude: 47.6062, zoom: 10.5 }
 const MOBILE_VIEW = { longitude: -122.336, latitude: 47.6062, zoom: 10.25 }
 
 type SelectedCrash = {


### PR DESCRIPTION
- When a State, County, or City filter is selected, the map now automatically animates to fit the bounds of matching crashes (`map.fitBounds()` with 80px padding, 800ms animation, max zoom 14)
- Single-crash results use `map.flyTo()` at zoom 13 instead
- Non-geographic filter changes (severity, mode, date) do not trigger auto-zoom — the user's manually panned viewport is preserved
- Implemented via a two-ref pattern in `CrashLayer.tsx`: `prevGeoRef` tracks prior geo filter values; `zoomPendingRef` flags a pending zoom; separate effects decouple filter-change detection from data-arrival execution

Closes #98