### PR TITLE
Set Default Filter State

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - `vitest.config.ts` — Vitest configuration with `@` path alias
 - `components/theme-provider.tsx` — thin `NextThemesProvider` wrapper (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
 - `components/ui/theme-toggle.tsx` — Sun/Moon icon button; CSS-driven icon swap via `dark:hidden`/`hidden dark:block`
-- `context/FilterContext.tsx` — React `useReducer` filter state; `FilterProvider`, `useFilterContext()`, `toCrashFilter()`, `getActiveFilterLabels()`
+- `context/FilterContext.tsx` — React `useReducer` filter state; `FilterProvider`, `useFilterContext()`, `toCrashFilter()`, `getActiveFilterLabels()`; default initialState: `state: 'Washington'`, `year: 2025`, `mode: null`
 - `components/layout/AppShell.tsx` — `'use client'` layout orchestrator; owns sidebar/overlay open state, renders SummaryBar and ThemeToggle
 - `components/map/MapContainer.tsx` — `'use client'` Mapbox map filling parent container
 - `components/sidebar/Sidebar.tsx` — Sheet-based right panel (desktop, ≥768px)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — Default Filter State (Washington, 2025, All Modes)
+
+- `initialState` in `FilterContext` now defaults to `state: 'Washington'`, `dateFilter: { type: 'year', year: 2025 }`, and `mode: null` (All modes) — the map loads focused on Washington 2025 data
+- `getActiveFilterLabels` now always emits a mode badge (`'All modes'` when null, `'Bicyclists'`/`'Pedestrians'` otherwise) so the SummaryBar always reflects the active mode selection; the existing `RESET` action returns to these same defaults
+
 ### 2026-02-19 — Auto-Zoom on Geographic Filter Change
 
 - When a State, County, or City filter is selected, the map now automatically animates to fit the bounds of matching crashes (`map.fitBounds()` with 80px padding, 800ms animation, max zoom 14)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.4.4
+**Version:** 0.4.5
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -59,8 +59,8 @@ const initialState: FilterState = {
   mode: null,
   severity: DEFAULT_SEVERITY,
   includeNoInjury: false,
-  dateFilter: { type: 'none' },
-  state: null,
+  dateFilter: { type: 'year', year: 2025 },
+  state: 'Washington',
   county: null,
   city: null,
   totalCount: null,
@@ -168,7 +168,7 @@ export function toCrashFilter(filterState: FilterState): CrashFilterInput {
 export function getActiveFilterLabels(filterState: FilterState): string[] {
   const labels: string[] = []
 
-  if (filterState.mode) labels.push(filterState.mode + 's')
+  labels.push(filterState.mode ? filterState.mode + 's' : 'All modes')
 
   // Only flag severity when it differs from the default three-bucket set.
   const defaultSet = new Set<string>(DEFAULT_SEVERITY)


### PR DESCRIPTION
- `initialState` in `FilterContext` now defaults to `state: 'Washington'`, `dateFilter: { type: 'year', year: 2025 }`, and `mode: null` (All modes) — the map loads focused on Washington 2025 data
- `getActiveFilterLabels` now always emits a mode badge (`'All modes'` when null, `'Bicyclists'`/`'Pedestrians'` otherwise) so the SummaryBar always reflects the active mode selection; the existing `RESET` action returns to these same defaults