### PR TITLE
Add Rate Limiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 - `lib/graphql/resolvers.ts` — All resolvers with severity bucket mapping and `buildWhere` helper
 - `app/api/graphql/route.ts` — Apollo Server route handler; also contains the inline `depthLimitRule` validation rule (max depth: 5)
 - `lib/graphql/__generated__/types.ts` — Generated GraphQL types (committed; regenerated via `npm run codegen`)
+- `lib/rate-limit.ts` — In-memory sliding window rate limiter (60 req/min per IP); `getClientIp()` reads `x-forwarded-for` for Render's proxy; periodic `setInterval` sweep evicts idle IPs
 - `lib/graphql/__tests__/helpers.test.ts` — Unit tests for `rawToBucket`, `bucketsToRawValues`, `buildWhere`
 - `lib/graphql/__tests__/queries.test.ts` — Integration tests for all GraphQL queries via `executeOperation` with mocked Prisma
 - `vitest.config.ts` — Vitest configuration with `@` path alias
@@ -300,11 +301,13 @@ Severity-based visual hierarchy using color, opacity, AND size:
 
 #### Milestone: Production-ready public application
 
-- [ ] Add rate limiting middleware for public API abuse prevention
+- [x] Add rate limiting middleware for public API abuse prevention
 - [ ] Configure CSP headers and CORS in Next.js
-- [ ] Add loading states, error boundaries, skeleton screens
+- [ ] Add loading states
+- [ ] Add error boundaries
+- [ ] Add skeleton screens
 - [ ] Implement URL-based state for shareable filter configurations (e.g., `?severity=Death&mode=Pedestrian&state=Ohio&county=Franklin`)
-- [ ] Add data export (CSV/PDF) for filtered results
+- [ ] Add data export (CSV) for filtered results
 - [ ] Accessibility audit (WCAG 2.1 AA)
 - [ ] Add a data disclaimer, methodology page, and links to bicycle/pedestrian safety resources
 - [ ] Deploy to Render with staging and production environments (Web Service for Next.js app, existing PostgreSQL database)
@@ -320,7 +323,7 @@ Severity-based visual hierarchy using color, opacity, AND size:
 ### Phase 5: Iteration (Ongoing)
 
 - [ ] Gather user feedback and iterate on visualizations
-- [ ] Hide None/Unknown injuries by default — Mapbox layer filter excludes the None bucket on initial load
+- [x] Hide None/Unknown injuries by default — Mapbox layer filter excludes the None bucket on initial load
 - [ ] Add mode stroke differentiation — stroke color distinguishes bicyclists (blue `#1565C0`) vs. pedestrians (purple `#4A148C`); stroke width scales with zoom
 - [ ] **Stretch goal: Dashboard charts** (see Section 11) — add Recharts/D3 visualizations for severity, mode, time trends, and geographic breakdowns
 - [ ] **Stretch goal: Mobile bottom sheet** (see Section 11) — upgrade from full-screen overlay using `vaul` or `react-modal-sheet` for peek/half/full snap states

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.4.5
+**Version:** 0.5.0
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,11 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-19 — Rate Limiting
+
+- Added `lib/rate-limit.ts` — zero-dependency in-memory sliding window rate limiter; 60 requests per minute per IP; `getClientIp()` reads the `x-forwarded-for` header (set by Render's proxy) to identify real client IPs; a `setInterval` sweep runs every 5 minutes to evict IPs with no recent activity
+- `GET` and `POST` handlers in `app/api/graphql/route.ts` now check the rate limit before delegating to Apollo Server; rate-limited requests receive a `429` response with a GraphQL-shaped `errors` body and a `Retry-After` header
 
 ### 2026-02-19 — Default Filter State (Washington, 2025, All Modes)
 

--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -5,6 +5,7 @@ import type { ASTNode, ValidationRule } from 'graphql'
 import { NextRequest } from 'next/server'
 import { typeDefs } from '@/lib/graphql/typeDefs'
 import { resolvers } from '@/lib/graphql/resolvers'
+import { getClientIp, checkRateLimit } from '@/lib/rate-limit'
 
 // ── Query depth limiting ──────────────────────────────────────────────────────
 // Rejects queries deeper than MAX_DEPTH before they reach any resolver.
@@ -39,9 +40,13 @@ const server = new ApolloServer({ typeDefs, resolvers, validationRules: [depthLi
 const handler = startServerAndCreateNextHandler<NextRequest>(server)
 
 export async function GET(request: NextRequest) {
+  const limited = checkRateLimit(getClientIp(request))
+  if (limited) return limited
   return handler(request)
 }
 
 export async function POST(request: NextRequest) {
+  const limited = checkRateLimit(getClientIp(request))
+  if (limited) return limited
   return handler(request)
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from 'next/server'
+
+const WINDOW_MS = 60_000
+const MAX_REQUESTS = 60
+
+// Map<ip, request timestamps[]> — timestamps are ms epoch values, oldest-first
+const store = new Map<string, number[]>()
+
+// Periodic sweep: evict IPs with no activity in the last window
+setInterval(
+  () => {
+    const cutoff = Date.now() - WINDOW_MS
+    for (const [ip, timestamps] of store) {
+      const fresh = timestamps.filter((t) => t >= cutoff)
+      if (fresh.length === 0) store.delete(ip)
+      else store.set(ip, fresh)
+    }
+  },
+  5 * 60 * 1000
+)
+
+export function getClientIp(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) return forwarded.split(',')[0].trim()
+  return '127.0.0.1'
+}
+
+/**
+ * Returns null if the request is allowed.
+ * Returns a 429 Response if the rate limit is exceeded.
+ */
+export function checkRateLimit(ip: string): Response | null {
+  const now = Date.now()
+  const cutoff = now - WINDOW_MS
+  const timestamps = (store.get(ip) ?? []).filter((t) => t >= cutoff)
+
+  if (timestamps.length >= MAX_REQUESTS) {
+    const retryAfter = Math.ceil((timestamps[0] + WINDOW_MS - now) / 1000)
+    return new Response(
+      JSON.stringify({
+        errors: [
+          {
+            message: 'Too many requests. Please slow down.',
+            extensions: { code: 'RATE_LIMITED' },
+          },
+        ],
+      }),
+      {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'Retry-After': String(retryAfter),
+        },
+      }
+    )
+  }
+
+  timestamps.push(now)
+  store.set(ip, timestamps)
+  return null
+}


### PR DESCRIPTION
- Added `lib/rate-limit.ts` — zero-dependency in-memory sliding window rate limiter; 60 requests per minute per IP; `getClientIp()` reads the `x-forwarded-for` header (set by Render's proxy) to identify real client IPs; a `setInterval` sweep runs every 5 minutes to evict IPs with no recent activity
- `GET` and `POST` handlers in `app/api/graphql/route.ts` now check the rate limit before delegating to Apollo Server; rate-limited requests receive a `429` response with a GraphQL-shaped `errors` body and a `Retry-After` header

Closes #101 