### PR TITLE
CSP Headers and CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ prisma/migrations/
 
 # claude
 .claude/
+CLAUDE.md
 
 # vercel
 .vercel
@@ -48,3 +49,4 @@ prisma/migrations/
 next-env.d.ts
 
 /lib/generated/prisma
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — CSP Headers and CORS
+
+- Added `Content-Security-Policy` header via `headers()` in `next.config.ts` — directives cover Next.js hydration (`unsafe-inline`; `unsafe-eval` in dev only for HMR), Mapbox tiles/telemetry (`*.mapbox.com`, `events.mapbox.com`), Mapbox blob: workers (`worker-src blob:`), and self-hosted Geist fonts (`font-src 'self'`)
+- Added `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and `Permissions-Policy` (camera, microphone, geolocation all denied) to all routes
+- Added `OPTIONS` preflight handler and CORS headers to `app/api/graphql/route.ts` — cross-origin access restricted to `crashmap.io`, `crashmap.onrender.com`, and `localhost:3000`; `withCors()` helper clones the Apollo handler response to attach headers cleanly without losing body/status
+
 ### 2026-02-19 — Rate Limiting
 
 - Added `lib/rate-limit.ts` — zero-dependency in-memory sliding window rate limiter; 60 requests per minute per IP; `getClientIp()` reads the `x-forwarded-for` header (set by Render's proxy) to identify real client IPs; a `setInterval` sweep runs every 5 minutes to evict IPs with no recent activity

--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -2,10 +2,46 @@ import { ApolloServer } from '@apollo/server'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import { GraphQLError, ValidationContext } from 'graphql'
 import type { ASTNode, ValidationRule } from 'graphql'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { typeDefs } from '@/lib/graphql/typeDefs'
 import { resolvers } from '@/lib/graphql/resolvers'
 import { getClientIp, checkRateLimit } from '@/lib/rate-limit'
+
+// ── CORS ──────────────────────────────────────────────────────────────────────
+// Restrict cross-origin access to known app origins. Same-origin requests from
+// crashmap.io itself do not need CORS headers, but these protect against
+// third-party sites driving traffic via browser-based cross-origin requests.
+
+const ALLOWED_ORIGINS = new Set([
+  'https://crashmap.io',
+  'https://crashmap.onrender.com',
+  'http://localhost:3000',
+])
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Max-Age': '86400',
+}
+
+function getCorsOrigin(request: NextRequest): string {
+  const origin = request.headers.get('origin')
+  return origin && ALLOWED_ORIGINS.has(origin) ? origin : 'https://crashmap.io'
+}
+
+// Clone a Response, copying its body/status/headers, then add CORS headers.
+async function withCors(response: Response, request: NextRequest): Promise<NextResponse> {
+  const headers = new Headers(response.headers)
+  headers.set('Access-Control-Allow-Origin', getCorsOrigin(request))
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    headers.set(key, value)
+  }
+  return new NextResponse(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
 
 // ── Query depth limiting ──────────────────────────────────────────────────────
 // Rejects queries deeper than MAX_DEPTH before they reach any resolver.
@@ -39,14 +75,18 @@ const server = new ApolloServer({ typeDefs, resolvers, validationRules: [depthLi
 
 const handler = startServerAndCreateNextHandler<NextRequest>(server)
 
+export async function OPTIONS(request: NextRequest) {
+  return withCors(new Response(null, { status: 204 }), request)
+}
+
 export async function GET(request: NextRequest) {
   const limited = checkRateLimit(getClientIp(request))
   if (limited) return limited
-  return handler(request)
+  return withCors(await handler(request), request)
 }
 
 export async function POST(request: NextRequest) {
   const limited = checkRateLimit(getClientIp(request))
   if (limited) return limited
-  return handler(request)
+  return withCors(await handler(request), request)
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,50 @@
 import type { NextConfig } from 'next'
 
+const isDev = process.env.NODE_ENV === 'development'
+
+// Mapbox requires:
+//   - connect-src: tile API, events/telemetry, geocoding
+//   - img-src: tile images, sprites (also blob: for canvas snapshots)
+//   - worker-src: mapbox-gl spawns workers via blob: URLs
+// Next.js requires:
+//   - script-src 'unsafe-inline': inline scripts for hydration
+//   - script-src 'unsafe-eval': HMR eval in dev only
+//   - style-src 'unsafe-inline': Tailwind / Mapbox inject inline styles
+// Geist font via next/font/google is self-hosted at build time — no external font-src needed.
+const cspDirectives = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.mapbox.com",
+  "connect-src 'self' https://*.mapbox.com https://events.mapbox.com",
+  'worker-src blob:',
+  "font-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ')
+
 const nextConfig: NextConfig = {
   output: 'standalone',
   transpilePackages: ['react-map-gl', 'mapbox-gl'],
   devIndicators: false,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'Content-Security-Policy', value: cspDirectives },
+          // belt-and-suspenders with frame-ancestors above
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          // deny access to hardware not used by this app
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
- Added `Content-Security-Policy` header via `headers()` in `next.config.ts` — directives cover Next.js hydration (`unsafe-inline`; `unsafe-eval` in dev only for HMR), Mapbox tiles/telemetry (`*.mapbox.com`, `events.mapbox.com`), Mapbox blob: workers (`worker-src blob:`), and self-hosted Geist fonts (`font-src 'self'`)
- Added `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and `Permissions-Policy` (camera, microphone, geolocation all denied) to all routes
- Added `OPTIONS` preflight handler and CORS headers to `app/api/graphql/route.ts` — cross-origin access restricted to `crashmap.io`, `crashmap.onrender.com`, and `localhost:3000`; `withCors()` helper clones the Apollo handler response to attach headers cleanly without losing body/status

Closes #102