### PR TITLE
Add Error Boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,3 +340,9 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - Refined generated Prisma model: renamed to `CrashData`, added camelCase field names with `@map` decorators and `@@map("crashdata")`
 - Ran `npx prisma generate` to produce typed client in `lib/generated/prisma/`
 - Added `lib/generated/prisma` to `.gitignore`
+
+### 2026-02-19 — Error Boundaries
+
+- Added `components/ErrorBoundary.tsx` — reusable React class component with a `fallback` prop; logs caught errors to console via `componentDidCatch`
+- Added `app/error.tsx` — Next.js route-level error page with a "Try again" reset button
+- Applied boundaries in `AppShell`: `MapContainer` gets a "Map failed to load / Refresh" full-screen fallback; `Sidebar` + `FilterOverlay` silently suppress (`fallback={null}`) so the map stays usable if filters crash

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex h-dvh w-full items-center justify-center bg-background">
+      <div className="space-y-3 text-center">
+        <p className="text-sm text-muted-foreground">Something went wrong.</p>
+        <Button variant="outline" size="sm" onClick={reset}>
+          Try again
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { Component, ReactNode } from 'react'
+
+type Props = {
+  children: ReactNode
+  fallback: ReactNode
+}
+
+type State = {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('ErrorBoundary caught:', error)
+  }
+
+  render() {
+    if (this.state.hasError) return this.props.fallback
+    return this.props.children
+  }
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -10,6 +10,18 @@ import { SummaryBar } from '@/components/summary/SummaryBar'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { useFilterContext, getActiveFilterLabels } from '@/context/FilterContext'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
+
+const mapFallback = (
+  <div className="flex h-full w-full items-center justify-center bg-background">
+    <div className="space-y-3 text-center">
+      <p className="text-sm text-muted-foreground">Map failed to load.</p>
+      <Button variant="outline" size="sm" onClick={() => window.location.reload()}>
+        Refresh
+      </Button>
+    </div>
+  </div>
+)
 
 export function AppShell() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -26,7 +38,9 @@ export function AppShell() {
 
   return (
     <>
-      <MapContainer ref={mapRef} />
+      <ErrorBoundary fallback={mapFallback}>
+        <MapContainer ref={mapRef} />
+      </ErrorBoundary>
 
       {/* Top-right controls */}
       <div className="absolute top-4 right-4 z-10 flex gap-2">
@@ -69,8 +83,10 @@ export function AppShell() {
         isLoading={filterState.isLoading}
       />
 
-      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-      <FilterOverlay isOpen={overlayOpen} onClose={() => setOverlayOpen(false)} />
+      <ErrorBoundary fallback={null}>
+        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+        <FilterOverlay isOpen={overlayOpen} onClose={() => setOverlayOpen(false)} />
+      </ErrorBoundary>
     </>
   )
 }


### PR DESCRIPTION
- Added `components/ErrorBoundary.tsx` — reusable React class component with a `fallback` prop; logs caught errors to console via `componentDidCatch`
- Added `app/error.tsx` — Next.js route-level error page with a "Try again" reset button
- Applied boundaries in `AppShell`: `MapContainer` gets a "Map failed to load / Refresh" full-screen fallback; `Sidebar` + `FilterOverlay` silently suppress (`fallback={null}`) so the map stays usable if filters crash

Closes #104 