### PR TITLE
Add  Skeleton Screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-19 — Skeleton Screens
+
+- Added `components/ui/skeleton.tsx` via `npx shadcn@latest add skeleton` — animated pulse rectangle used as a placeholder wherever data is still loading
+- `GeographicFilter` now shows three skeleton rectangles (matching the height of the Select dropdowns) while the initial `filterOptions` query is in flight — replaces the previous behavior of rendering disabled, empty dropdowns
+- `SummaryBar` now shows an inline skeleton pill in place of the `—` dash while `crashCount` is null (the initial query hasn't resolved yet); once data arrives it switches to the real count with the existing pulse/spinner for subsequent refetches
+
 ### 2026-02-19 — Loading States
 
 - `GeographicFilter` now captures `loading` from the counties and cities queries; a `Loader2` spinner appears next to the "Location" label while either cascading query is in flight

--- a/components/filters/GeographicFilter.tsx
+++ b/components/filters/GeographicFilter.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useFilterContext } from '@/context/FilterContext'
 import {
   GET_FILTER_OPTIONS,
@@ -25,7 +26,8 @@ const ALL = '__all__'
 export function GeographicFilter() {
   const { filterState, dispatch } = useFilterContext()
 
-  const { data: optionsData } = useQuery<GetFilterOptionsQuery>(GET_FILTER_OPTIONS)
+  const { data: optionsData, loading: optionsLoading } =
+    useQuery<GetFilterOptionsQuery>(GET_FILTER_OPTIONS)
 
   const { data: countiesData, loading: countiesLoading } = useQuery<GetCountiesQuery>(
     GET_COUNTIES,
@@ -54,6 +56,17 @@ export function GeographicFilter() {
 
   function handleCityChange(value: string) {
     dispatch({ type: 'SET_CITY', payload: value === ALL ? null : value })
+  }
+
+  if (optionsLoading) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Location</p>
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+      </div>
+    )
   }
 
   return (

--- a/components/summary/SummaryBar.tsx
+++ b/components/summary/SummaryBar.tsx
@@ -2,6 +2,7 @@
 
 import { Loader2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 
 interface SummaryBarProps {
   crashCount?: number | null
@@ -25,7 +26,13 @@ export function SummaryBar({
     >
       <span className="flex items-center gap-1.5 text-sm font-medium tabular-nums whitespace-nowrap">
         {isLoading && <Loader2 className="size-3 animate-spin" aria-hidden="true" />}
-        <span className={isLoading ? 'animate-pulse' : ''}>{countLabel} crashes</span>
+        {crashCount === null ? (
+          <>
+            <Skeleton className="inline-block h-4 w-10 align-middle" /> crashes
+          </>
+        ) : (
+          <span className={isLoading ? 'animate-pulse' : ''}>{countLabel} crashes</span>
+        )}
       </span>
 
       {activeFilters.length > 0 && (

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-accent animate-pulse rounded-md', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
- Added `components/ui/skeleton.tsx` via `npx shadcn@latest add skeleton` — animated pulse rectangle used as a placeholder wherever data is still loading
- `GeographicFilter` now shows three skeleton rectangles (matching the height of the Select dropdowns) while the initial `filterOptions` query is in flight — replaces the previous behavior of rendering disabled, empty dropdowns
- `SummaryBar` now shows an inline skeleton pill in place of the `—` dash while `crashCount` is null (the initial query hasn't resolved yet); once data arrives it switches to the real count with the existing pulse/spinner for subsequent refetches

Closes #105 