### PR TITLE
Shareable Filter URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-20 — Shareable Filter URLs
+
+- Added `lib/filterUrlState.ts` — pure `encodeFilterParams` / `decodeFilterParams` utilities that convert `FilterState` to/from `URLSearchParams`; default values are omitted so a clean URL (`/`) means the default view (Washington, 2025, all modes); `?state=none` encodes null/all-states; `None` in the severity CSV encodes `includeNoInjury`
+- Added `components/FilterUrlSync.tsx` — invisible client component that syncs URL ↔ `FilterContext` via two effects: mount reads URL → `INIT_FROM_URL` dispatch; subsequent filter changes → `router.replace` (no history pollution); `skipFirstSyncRef` prevents the initial render from overwriting an incoming shared URL with defaults
+- Added `INIT_FROM_URL` action and `UrlFilterState` exported type to `context/FilterContext.tsx` — atomic state write that bypasses cascading reset logic
+- Wired `<FilterUrlSync />` in `app/layout.tsx` inside `<Suspense fallback={null}>` within `FilterProvider` (required by `useSearchParams` in the App Router)
+
 ### 2026-02-19 — Skeleton Screens
 
 - Added `components/ui/skeleton.tsx` via `npx shadcn@latest add skeleton` — animated pulse rectangle used as a placeholder wherever data is still loading

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { ApolloProvider } from './apollo-provider'
 import { ThemeProvider } from '@/components/theme-provider'
 import { FilterProvider } from '@/context/FilterContext'
+import { FilterUrlSync } from '@/components/FilterUrlSync'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './globals.css'
 
@@ -36,7 +38,12 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <ApolloProvider>
-            <FilterProvider>{children}</FilterProvider>
+            <FilterProvider>
+              <Suspense fallback={null}>
+                <FilterUrlSync />
+              </Suspense>
+              {children}
+            </FilterProvider>
           </ApolloProvider>
         </ThemeProvider>
       </body>

--- a/components/FilterUrlSync.tsx
+++ b/components/FilterUrlSync.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useFilterContext } from '@/context/FilterContext'
+import { decodeFilterParams, encodeFilterParams } from '@/lib/filterUrlState'
+
+/**
+ * Invisible bridge component that keeps URL query params and FilterContext in sync.
+ *
+ * Effect 1 (mount only): reads current URL params → dispatches INIT_FROM_URL.
+ * Effect 2 (every filterState change): encodes current filter state → router.replace.
+ *
+ * skipFirstSyncRef prevents Effect 2 from overwriting the incoming URL on the
+ * first render (before Effect 1's dispatch has been processed by the reducer).
+ *
+ * Must be rendered inside <FilterProvider> and wrapped in <Suspense> at the
+ * call site (required by useSearchParams in the Next.js App Router).
+ */
+export function FilterUrlSync() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { filterState, dispatch } = useFilterContext()
+
+  // Skip the first firing of Effect 2, which runs against initialState before
+  // INIT_FROM_URL has been processed. Set to true initially, consumed once.
+  const skipFirstSyncRef = useRef(true)
+
+  // Effect 1: URL → state (mount only)
+  useEffect(() => {
+    dispatch({ type: 'INIT_FROM_URL', payload: decodeFilterParams(searchParams) })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Effect 2: state → URL (runs after every filterState change)
+  useEffect(() => {
+    if (skipFirstSyncRef.current) {
+      skipFirstSyncRef.current = false
+      return
+    }
+    const params = encodeFilterParams(filterState)
+    const search = params.toString()
+    router.replace(search ? `?${search}` : '/', { scroll: false })
+  }, [filterState, router])
+
+  return null
+}

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -24,6 +24,17 @@ export interface FilterState {
   isLoading: boolean // true while a filter-triggered refetch is in flight
 }
 
+// The URL-serializable subset of FilterState (no derived fields).
+export type UrlFilterState = {
+  mode: ModeFilter
+  severity: SeverityBucket[]
+  includeNoInjury: boolean
+  dateFilter: DateFilter
+  state: string | null
+  county: string | null
+  city: string | null
+}
+
 export type FilterAction =
   | { type: 'SET_MODE'; payload: ModeFilter }
   | { type: 'SET_SEVERITY'; payload: SeverityBucket[] }
@@ -37,6 +48,7 @@ export type FilterAction =
   | { type: 'SET_TOTAL_COUNT'; payload: number | null }
   | { type: 'SET_LOADING'; payload: boolean }
   | { type: 'RESET' }
+  | { type: 'INIT_FROM_URL'; payload: UrlFilterState }
 
 // Matches the CrashFilter GraphQL input shape (used as Apollo query variables).
 export type CrashFilterInput = {
@@ -104,6 +116,17 @@ function filterReducer(filterState: FilterState, action: FilterAction): FilterSt
       return { ...filterState, isLoading: action.payload }
     case 'RESET':
       return initialState
+    case 'INIT_FROM_URL':
+      return {
+        ...filterState,
+        mode: action.payload.mode,
+        severity: action.payload.severity,
+        includeNoInjury: action.payload.includeNoInjury,
+        dateFilter: action.payload.dateFilter,
+        state: action.payload.state,
+        county: action.payload.county,
+        city: action.payload.city,
+      }
     default:
       return filterState
   }

--- a/lib/filterUrlState.ts
+++ b/lib/filterUrlState.ts
@@ -1,0 +1,148 @@
+import type { DateFilter, FilterState, ModeFilter, SeverityBucket } from '@/context/FilterContext'
+import { DEFAULT_SEVERITY } from '@/context/FilterContext'
+
+// The URL-serializable subset of FilterState (no derived fields).
+export type UrlFilterState = {
+  mode: ModeFilter
+  severity: SeverityBucket[]
+  includeNoInjury: boolean
+  dateFilter: DateFilter
+  state: string | null
+  county: string | null
+  city: string | null
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_STATE = 'Washington'
+const DEFAULT_YEAR = 2025
+const DEFAULT_SEVERITY_SET = new Set<string>(DEFAULT_SEVERITY)
+const VALID_SEVERITY_BUCKETS = new Set<string>(['Death', 'Major Injury', 'Minor Injury', 'None'])
+const VALID_MODES = new Set<string>(['Bicyclist', 'Pedestrian'])
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+function isDefaultSeverity(severity: SeverityBucket[], includeNoInjury: boolean): boolean {
+  if (includeNoInjury) return false
+  if (severity.length !== DEFAULT_SEVERITY.length) return false
+  return severity.every((b) => DEFAULT_SEVERITY_SET.has(b))
+}
+
+// ── Encode ────────────────────────────────────────────────────────────────────
+
+/**
+ * Converts the URL-serializable portion of FilterState into URLSearchParams.
+ * Default values are omitted — a clean URL (no params) means the default view.
+ */
+export function encodeFilterParams(filterState: FilterState): URLSearchParams {
+  const params = new URLSearchParams()
+
+  // mode — omit when null (all modes)
+  if (filterState.mode !== null) {
+    params.set('mode', filterState.mode)
+  }
+
+  // severity — omit when it exactly matches the default 3-bucket set + no None
+  if (!isDefaultSeverity(filterState.severity, filterState.includeNoInjury)) {
+    const buckets: string[] = [
+      ...filterState.severity,
+      ...(filterState.includeNoInjury ? ['None'] : []),
+    ]
+    params.set('severity', buckets.join(','))
+  }
+
+  // dateFilter — omit when it's the default (year 2025)
+  const { dateFilter } = filterState
+  if (dateFilter.type === 'none') {
+    params.set('date', 'none')
+  } else if (dateFilter.type === 'year' && dateFilter.year !== DEFAULT_YEAR) {
+    params.set('year', String(dateFilter.year))
+  } else if (dateFilter.type === 'range') {
+    params.set('dateFrom', dateFilter.startDate)
+    params.set('dateTo', dateFilter.endDate)
+  }
+  // year === DEFAULT_YEAR → omit
+
+  // state — omit when it matches the default ('Washington')
+  if (filterState.state !== DEFAULT_STATE) {
+    // null means "all states"; use sentinel so it round-trips correctly
+    params.set('state', filterState.state === null ? 'none' : filterState.state)
+  }
+
+  // county/city — omit when null
+  if (filterState.county !== null) {
+    params.set('county', filterState.county)
+  }
+  if (filterState.city !== null) {
+    params.set('city', filterState.city)
+  }
+
+  return params
+}
+
+// ── Decode ────────────────────────────────────────────────────────────────────
+
+/**
+ * Parses URLSearchParams back into a UrlFilterState.
+ * Falls back to application defaults for absent or invalid params.
+ */
+export function decodeFilterParams(params: URLSearchParams): UrlFilterState {
+  // mode
+  const rawMode = params.get('mode')
+  const mode: ModeFilter =
+    rawMode !== null && VALID_MODES.has(rawMode) ? (rawMode as ModeFilter) : null
+
+  // severity (CSV, with 'None' doubling as includeNoInjury)
+  let severity: SeverityBucket[] = [...DEFAULT_SEVERITY]
+  let includeNoInjury = false
+  const rawSeverity = params.get('severity')
+  if (rawSeverity !== null) {
+    const parsed = rawSeverity
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => VALID_SEVERITY_BUCKETS.has(s))
+    const hasNone = parsed.includes('None')
+    const nonNone = parsed.filter((s): s is SeverityBucket => s !== 'None') as SeverityBucket[]
+    if (parsed.length > 0) {
+      severity = nonNone
+      includeNoInjury = hasNone
+    }
+    // if every token was invalid, fall back to defaults (severity unchanged)
+  }
+
+  // dateFilter
+  let dateFilter: DateFilter = { type: 'year', year: DEFAULT_YEAR }
+  const rawDate = params.get('date')
+  const rawYear = params.get('year')
+  const rawDateFrom = params.get('dateFrom')
+  const rawDateTo = params.get('dateTo')
+
+  if (rawDate === 'none') {
+    dateFilter = { type: 'none' }
+  } else if (rawDateFrom !== null && rawDateTo !== null) {
+    if (ISO_DATE_RE.test(rawDateFrom) && ISO_DATE_RE.test(rawDateTo)) {
+      dateFilter = { type: 'range', startDate: rawDateFrom, endDate: rawDateTo }
+    }
+  } else if (rawYear !== null) {
+    const year = parseInt(rawYear, 10)
+    if (!isNaN(year) && year >= 2000 && year <= 2100) {
+      dateFilter = { type: 'year', year }
+    }
+  }
+
+  // state: absent → default 'Washington'; 'none' → null; other → string
+  let state: string | null = DEFAULT_STATE
+  if (params.has('state')) {
+    const rawState = params.get('state')!
+    state = rawState === 'none' ? null : rawState
+  }
+
+  // county: only set if state is non-null (guard orphan params)
+  const rawCounty = params.get('county')
+  const county: string | null = rawCounty !== null && state !== null ? rawCounty : null
+
+  // city: only set if county is non-null
+  const rawCity = params.get('city')
+  const city: string | null = rawCity !== null && county !== null ? rawCity : null
+
+  return { mode, severity, includeNoInjury, dateFilter, state, county, city }
+}


### PR DESCRIPTION
- Added `lib/filterUrlState.ts` — pure `encodeFilterParams` / `decodeFilterParams` utilities that convert `FilterState` to/from `URLSearchParams`; default values are omitted so a clean URL (`/`) means the default view (Washington, 2025, all modes); `?state=none` encodes null/all-states; `None` in the severity CSV encodes `includeNoInjury`
- Added `components/FilterUrlSync.tsx` — invisible client component that syncs URL ↔ `FilterContext` via two effects: mount reads URL → `INIT_FROM_URL` dispatch; subsequent filter changes → `router.replace` (no history pollution); `skipFirstSyncRef` prevents the initial render from overwriting an incoming shared URL with defaults
- Added `INIT_FROM_URL` action and `UrlFilterState` exported type to `context/FilterContext.tsx` — atomic state write that bypasses cascading reset logic
- Wired `<FilterUrlSync />` in `app/layout.tsx` inside `<Suspense fallback={null}>` within `FilterProvider` (required by `useSearchParams` in the App Router)

Closes #106