### PR TITLE
CSV Data Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-20 — CSV Data Export
+
+- Added `lib/csv-export.ts` — `generateCsv()` converts crash records to a UTF-8 CSV string with BOM (for Excel compatibility) and `downloadCsv()` triggers a browser file download; no external dependencies
+- Added `GET_CRASHES_EXPORT` GraphQL query to `lib/graphql/queries.ts` — fetches all fields needed for export (colliRptNum, crashDate, time, injuryType, mode, state, county, city, jurisdiction, region, ageGroup, involvedPersons, latitude, longitude)
+- Added `components/export/ExportButton.tsx` — self-contained client component using `useLazyQuery`; fires on click with the current filter state (up to 5000 records); two variants: `icon` (ghost icon button for the SummaryBar pill) and `full` (full-width outline button for Sidebar/FilterOverlay); filename includes active geo and date filters (e.g. `crashmap-washington-king-2025-2026-02-20.csv`)
+- `SummaryBar` now accepts an optional `actions` slot (rendered with a separator after the filter badges); `AppShell` passes `<ExportButton variant="icon" />` there
+- `Sidebar` and `FilterOverlay` each include `<ExportButton variant="full" />` at the bottom of their filter lists
+
+### 2026-02-20 — Jurisdiction in Crash Popup
+
+- Added `jurisdiction` field to the `GET_CRASHES` GraphQL query, `CrashLayer` GeoJSON properties, and `MapContainer` `SelectedCrash` type
+- Popup now displays jurisdiction beneath the city/county line when present
+
 ### 2026-02-20 — Crash Layer Z-Ordering and Zoom Scaling
 
 - Split `CrashLayer` from a single `crashes-circles` layer into four separate Mapbox layers (`crashes-none`, `crashes-minor`, `crashes-major`, `crashes-death`) — layers render in order, so Death dots now always appear on top of Major Injury, which appear on top of Minor Injury, etc.

--- a/components/export/ExportButton.tsx
+++ b/components/export/ExportButton.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { Download, Loader2 } from 'lucide-react'
+import { useLazyQuery } from '@apollo/client/react'
+import { Button } from '@/components/ui/button'
+import { useFilterContext, toCrashFilter } from '@/context/FilterContext'
+import { GET_CRASHES_EXPORT, type GetCrashesExportQuery } from '@/lib/graphql/queries'
+import { generateCsv, downloadCsv } from '@/lib/csv-export'
+import type { FilterState } from '@/context/FilterContext'
+
+function buildFilename(filterState: FilterState): string {
+  const parts: string[] = ['crashmap']
+
+  if (filterState.state) {
+    parts.push(filterState.state.toLowerCase().replace(/\s+/g, '-'))
+  }
+  if (filterState.county) {
+    parts.push(filterState.county.toLowerCase().replace(/\s+/g, '-'))
+  }
+  if (filterState.city) {
+    parts.push(filterState.city.toLowerCase().replace(/\s+/g, '-'))
+  }
+
+  if (filterState.dateFilter.type === 'year') {
+    parts.push(String(filterState.dateFilter.year))
+  } else if (filterState.dateFilter.type === 'range') {
+    parts.push(filterState.dateFilter.startDate.slice(0, 10))
+    parts.push(filterState.dateFilter.endDate.slice(0, 10))
+  }
+
+  parts.push(new Date().toISOString().slice(0, 10))
+  return parts.join('-') + '.csv'
+}
+
+interface ExportButtonProps {
+  variant?: 'icon' | 'full'
+}
+
+export function ExportButton({ variant = 'icon' }: ExportButtonProps) {
+  const { filterState } = useFilterContext()
+  const [fetchCrashes, { loading }] = useLazyQuery<GetCrashesExportQuery>(GET_CRASHES_EXPORT)
+
+  async function handleExport() {
+    const { data } = await fetchCrashes({
+      variables: { filter: toCrashFilter(filterState), limit: 5000 },
+    })
+    if (!data) return
+
+    const csv = generateCsv(data.crashes.items)
+    downloadCsv(csv, buildFilename(filterState))
+  }
+
+  if (variant === 'full') {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleExport}
+        disabled={loading}
+        className="w-full gap-2"
+      >
+        {loading ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+        {loading ? 'Exporting…' : 'Export CSV'}
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleExport}
+      disabled={loading}
+      aria-label="Export CSV"
+      title="Export CSV"
+    >
+      {loading ? <Loader2 className="size-3 animate-spin" /> : <Download className="size-3" />}
+    </Button>
+  )
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -7,6 +7,7 @@ import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
 import { FilterOverlay } from '@/components/overlay/FilterOverlay'
 import { SummaryBar } from '@/components/summary/SummaryBar'
+import { ExportButton } from '@/components/export/ExportButton'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { useFilterContext, getActiveFilterLabels } from '@/context/FilterContext'
@@ -81,6 +82,7 @@ export function AppShell() {
         crashCount={filterState.totalCount}
         activeFilters={getActiveFilterLabels(filterState)}
         isLoading={filterState.isLoading}
+        actions={<ExportButton variant="icon" />}
       />
 
       <ErrorBoundary fallback={null}>

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -20,6 +20,7 @@ type CrashItem = {
   involvedPersons: number | null
   city: string | null
   county: string | null
+  jurisdiction: string | null
 }
 
 type GetCrashesQuery = {
@@ -205,6 +206,7 @@ export function CrashLayer() {
           involvedPersons: crash.involvedPersons,
           city: crash.city,
           county: crash.county,
+          jurisdiction: crash.jurisdiction,
         },
       })),
   }

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -22,6 +22,7 @@ type SelectedCrash = {
   involvedPersons: number | null
   city: string | null
   county: string | null
+  jurisdiction: string | null
 }
 
 const SEVERITY_COLORS: Record<string, string> = {
@@ -80,6 +81,7 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
         involvedPersons: p.involvedPersons as number | null,
         city: p.city as string | null,
         county: p.county as string | null,
+        jurisdiction: p.jurisdiction as string | null,
       })
     },
     []
@@ -139,6 +141,9 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
               <div style={{ color: 'var(--muted-foreground)' }}>
                 {[selectedCrash.city, selectedCrash.county].filter(Boolean).join(', ')}
               </div>
+            )}
+            {selectedCrash.jurisdiction && (
+              <div style={{ color: 'var(--muted-foreground)' }}>{selectedCrash.jurisdiction}</div>
             )}
             {selectedCrash.involvedPersons != null && (
               <div style={{ color: 'var(--muted-foreground)' }}>

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -6,6 +6,7 @@ import { ModeToggle } from '@/components/filters/ModeToggle'
 import { SeverityFilter } from '@/components/filters/SeverityFilter'
 import { DateFilter } from '@/components/filters/DateFilter'
 import { GeographicFilter } from '@/components/filters/GeographicFilter'
+import { ExportButton } from '@/components/export/ExportButton'
 
 interface FilterOverlayProps {
   isOpen: boolean
@@ -34,6 +35,10 @@ export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
         <DateFilter />
         <SeverityFilter />
         <GeographicFilter />
+      </div>
+
+      <div className="border-t px-4 py-3">
+        <ExportButton variant="full" />
       </div>
     </div>
   )

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import { ModeToggle } from '@/components/filters/ModeToggle'
 import { SeverityFilter } from '@/components/filters/SeverityFilter'
 import { DateFilter } from '@/components/filters/DateFilter'
 import { GeographicFilter } from '@/components/filters/GeographicFilter'
+import { ExportButton } from '@/components/export/ExportButton'
 
 interface SidebarProps {
   isOpen: boolean
@@ -21,6 +22,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           <DateFilter />
           <SeverityFilter />
           <GeographicFilter />
+          <ExportButton variant="full" />
         </div>
       </SheetContent>
     </Sheet>

--- a/components/summary/SummaryBar.tsx
+++ b/components/summary/SummaryBar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { Loader2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -8,12 +9,14 @@ interface SummaryBarProps {
   crashCount?: number | null
   activeFilters?: string[]
   isLoading?: boolean
+  actions?: React.ReactNode
 }
 
 export function SummaryBar({
   crashCount = null,
   activeFilters = [],
   isLoading = false,
+  actions,
 }: SummaryBarProps) {
   const countLabel = crashCount === null ? '—' : crashCount.toLocaleString()
 
@@ -45,6 +48,13 @@ export function SummaryBar({
               </Badge>
             ))}
           </div>
+        </>
+      )}
+
+      {actions && (
+        <>
+          <div className="h-4 w-px bg-border" aria-hidden="true" />
+          {actions}
         </>
       )}
     </div>

--- a/lib/csv-export.ts
+++ b/lib/csv-export.ts
@@ -1,0 +1,74 @@
+type CrashRow = {
+  colliRptNum: string
+  crashDate?: string | null
+  time?: string | null
+  injuryType?: string | null
+  mode?: string | null
+  state?: string | null
+  county?: string | null
+  city?: string | null
+  jurisdiction?: string | null
+  region?: string | null
+  ageGroup?: string | null
+  involvedPersons?: number | null
+  latitude?: number | null
+  longitude?: number | null
+}
+
+const HEADERS = [
+  'Collision Report #',
+  'Date',
+  'Time',
+  'Injury Type',
+  'Mode',
+  'State',
+  'County',
+  'City',
+  'Jurisdiction',
+  'Region',
+  'Age Group',
+  'Involved Persons',
+  'Latitude',
+  'Longitude',
+]
+
+function escapeCell(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+export function generateCsv(items: CrashRow[]): string {
+  const rows = items.map((item) => [
+    item.colliRptNum,
+    item.crashDate ?? '',
+    item.time ?? '',
+    item.injuryType ?? '',
+    item.mode ?? '',
+    item.state ?? '',
+    item.county ?? '',
+    item.city ?? '',
+    item.jurisdiction ?? '',
+    item.region ?? '',
+    item.ageGroup ?? '',
+    item.involvedPersons?.toString() ?? '',
+    item.latitude?.toString() ?? '',
+    item.longitude?.toString() ?? '',
+  ])
+
+  const lines = [HEADERS, ...rows].map((row) => row.map(escapeCell).join(','))
+  return '\ufeff' + lines.join('\r\n') // BOM prefix for Excel compatibility
+}
+
+export function downloadCsv(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -63,8 +63,55 @@ export const GET_CRASHES = gql`
         involvedPersons
         city
         county
+        jurisdiction
       }
       totalCount
     }
   }
 `
+
+export const GET_CRASHES_EXPORT = gql`
+  query GetCrashesExport($filter: CrashFilter, $limit: Int) {
+    crashes(filter: $filter, limit: $limit) {
+      items {
+        colliRptNum
+        crashDate
+        time
+        injuryType
+        mode
+        state
+        county
+        city
+        jurisdiction
+        region
+        ageGroup
+        involvedPersons
+        latitude
+        longitude
+      }
+      totalCount
+    }
+  }
+`
+
+export type GetCrashesExportQuery = {
+  crashes: {
+    items: Array<{
+      colliRptNum: string
+      crashDate?: string | null
+      time?: string | null
+      injuryType?: string | null
+      mode?: string | null
+      state?: string | null
+      county?: string | null
+      city?: string | null
+      jurisdiction?: string | null
+      region?: string | null
+      ageGroup?: string | null
+      involvedPersons?: number | null
+      latitude?: number | null
+      longitude?: number | null
+    }>
+    totalCount: number
+  }
+}


### PR DESCRIPTION
- Added `lib/csv-export.ts` — `generateCsv()` converts crash records to a UTF-8 CSV string with BOM (for Excel compatibility) and `downloadCsv()` triggers a browser file download; no external dependencies
- Added `GET_CRASHES_EXPORT` GraphQL query to `lib/graphql/queries.ts` — fetches all fields needed for export (colliRptNum, crashDate, time, injuryType, mode, state, county, city, jurisdiction, region, ageGroup, involvedPersons, latitude, longitude)
- Added `components/export/ExportButton.tsx` — self-contained client component using `useLazyQuery`; fires on click with the current filter state (up to 5000 records); two variants: `icon` (ghost icon button for the SummaryBar pill) and `full` (full-width outline button for Sidebar/FilterOverlay); filename includes active geo and date filters (e.g. `crashmap-washington-king-2025-2026-02-20.csv`)
- `SummaryBar` now accepts an optional `actions` slot (rendered with a separator after the filter badges); `AppShell` passes `<ExportButton variant="icon" />` there
- `Sidebar` and `FilterOverlay` each include `<ExportButton variant="full" />` at the bottom of their filter lists

Closes #107 