### PR TITLE
Add About Panel, Pinnable Panels, and Emoji Favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CrashMap
 
-**Version:** 0.5.0
+**Version:** 0.5.4
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
@@ -44,6 +44,15 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ---
 
 ## Changelog
+
+### 2026-02-20 — About Panel, Pinnable Panels, and Emoji Favicon
+
+- Added `components/info/InfoPanelContent.tsx` — content for the About panel: a dedication, data description (with link to the WSDOT Crash Data Portal), a map key showing severity color legend, a data disclaimer, and a "Get Involved" list of bicycle/pedestrian safety and advocacy resources
+- Added `components/info/InfoOverlay.tsx` — mobile full-screen About overlay (mirrors `FilterOverlay`, hidden on desktop via `md:hidden`)
+- Added `components/info/InfoSidePanel.tsx` — desktop About panel with two rendering modes: Sheet (slides from left, with Pin button) and pinned div (flex column, with PinOff + Close buttons)
+- Modified `components/sidebar/Sidebar.tsx` — added pinnable mode: Sheet renders with a Pin button; pinned renders as a flex column with PinOff + Close header; `showCloseButton={false}` so the custom header owns both actions consistently
+- Refactored `components/layout/AppShell.tsx` — outer flex container so pinned panels push the map rather than overlaying it; `sidebarOpen`/`sidebarPinned`/`infoPanelOpen`/`infoPanelPinned` state; both panels default to open + pinned on desktop; `map.resize()` fires on all panel state changes; Info button added to top-left
+- Changed favicon to 💥 emoji via inline SVG data URI in `app/layout.tsx` metadata
 
 ### 2026-02-20 — CSV Data Export
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: 'CrashMap',
   description: 'Bike & Ped Crash Data Mapped',
+  icons: {
+    icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💥</text></svg>",
+  },
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { AppShell } from '@/components/layout/AppShell'
 
 export default function Home() {
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100dvh' }}>
+    <div style={{ width: '100%', height: '100dvh' }}>
       <AppShell />
     </div>
   )

--- a/components/info/InfoOverlay.tsx
+++ b/components/info/InfoOverlay.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { InfoPanelContent } from './InfoPanelContent'
+
+interface InfoOverlayProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function InfoOverlay({ isOpen, onClose }: InfoOverlayProps) {
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-20 flex flex-col bg-background md:hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-label="About"
+    >
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h2 className="text-base font-semibold">💥CrashMap</h2>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+          <X className="size-4" />
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <InfoPanelContent />
+      </div>
+    </div>
+  )
+}

--- a/components/info/InfoPanelContent.tsx
+++ b/components/info/InfoPanelContent.tsx
@@ -1,0 +1,116 @@
+import { ExternalLink } from 'lucide-react'
+
+const resources = [
+  {
+    href: 'https://wabikes.org/',
+    label: 'Washington Bikes: The Political Voice for People Who Bike',
+  },
+  {
+    href: 'https://www.seattlegreenways.org/',
+    label: 'Seattle Neighborhood Greenways',
+  },
+  {
+    href: 'https://spokanereimagined.org/',
+    label: 'Spokane Reimagined',
+  },
+  {
+    href: 'https://www.safest.org/',
+    label: 'Safe Streets Pierce County',
+  },
+  {
+    href: 'https://www.cityofvancouver.us/business/planning-development-and-zoning/transportation-planning/complete-streets/',
+    label: 'Vancouver Complete Streets',
+  },
+]
+
+export function InfoPanelContent() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold">About</h2>
+        <p className="text-xs text-muted-foreground/60 mt-0.5">
+          Version 0.5.4 &middot; Updated 2/20/2026
+        </p>
+      </div>
+
+      <section>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          This map is dedicated to all victims of traffic violence and their loved ones, across
+          Washington State and the world. Traffic violence is an epidemic that leaves countless
+          lives irreparably damaged or ended far too soon. I hope this can be used as a tool to
+          conceptualize and ingrain the true scale of the damage this violence bares on our
+          communities. For each dot on this map, let&apos;s fight for safe streets.
+        </p>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-semibold mb-2">The Data</h3>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Each record represents a reported crash involving at least one &quot;pedacyclist&quot; or
+          pedestrian with a known location. Crashes are classified by the most severe injury to any
+          person involved. Currently includes data from Washington State. In the case of duplicate
+          reports, I used the most vulnerable mode listed on the report(pedestrian &gt; bicycle &gt;
+          car). All data is from WSDOT, mirroring the data from the{' '}
+          <a
+            href="https://remoteapps.wsdot.wa.gov/highwaysafety/collision/data/portal/public/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline inline-flex items-center gap-0.5"
+          >
+            WSDOT Crash Data Portal
+            <ExternalLink className="size-3 flex-shrink-0" />
+          </a>
+          , which is compiled from police reports.
+        </p>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-semibold mb-3">Map Key</h3>
+        <ul className="space-y-2">
+          {[
+            { color: '#B71C1C', opacity: 0.85, size: 14, label: 'Fatal' },
+            { color: '#E65100', opacity: 0.7, size: 12, label: 'Major Injury' },
+            { color: '#F9A825', opacity: 0.55, size: 11, label: 'Minor Injury' },
+            { color: '#C5E1A5', opacity: 0.5, size: 10, label: 'No Injury / Unknown' },
+          ].map(({ color, opacity, size, label }) => (
+            <li key={label} className="flex items-center gap-2.5">
+              <span
+                className="flex-shrink-0 rounded-full"
+                style={{ width: size, height: size, backgroundColor: color, opacity }}
+              />
+              <span className="text-sm text-muted-foreground">{label}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-semibold mb-2">Data Disclaimer</h3>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          This data is self-collected from publicly available state transportation department
+          records. It may be incomplete, contain errors, or not reflect the most recent crashes. It
+          should not be used as the sole basis for safety decisions or policy.
+        </p>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-semibold mb-2">📣 Get Involved!</h3>
+        <ul className="space-y-2.5">
+          {resources.map(({ href, label }) => (
+            <li key={href}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-primary inline-flex items-center gap-1 hover:underline"
+              >
+                {label}
+                <ExternalLink className="size-3 flex-shrink-0" />
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/components/info/InfoSidePanel.tsx
+++ b/components/info/InfoSidePanel.tsx
@@ -3,46 +3,30 @@
 import { Pin, PinOff, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetTitle, SheetClose } from '@/components/ui/sheet'
-import { ModeToggle } from '@/components/filters/ModeToggle'
-import { SeverityFilter } from '@/components/filters/SeverityFilter'
-import { DateFilter } from '@/components/filters/DateFilter'
-import { GeographicFilter } from '@/components/filters/GeographicFilter'
-import { ExportButton } from '@/components/export/ExportButton'
+import { InfoPanelContent } from './InfoPanelContent'
 
-interface SidebarProps {
+interface InfoSidePanelProps {
   pinned: boolean
   onClose: () => void
   onTogglePin: () => void
   isOpen?: boolean
 }
 
-function FilterContent() {
-  return (
-    <div className="space-y-6 px-4 py-4">
-      <ModeToggle />
-      <DateFilter />
-      <SeverityFilter />
-      <GeographicFilter />
-      <ExportButton variant="full" />
-    </div>
-  )
-}
-
-export function Sidebar({ pinned, onClose, onTogglePin, isOpen }: SidebarProps) {
+export function InfoSidePanel({ pinned, onClose, onTogglePin, isOpen }: InfoSidePanelProps) {
   if (pinned) {
     return (
-      <div className="hidden md:flex flex-col w-80 flex-shrink-0 border-l bg-background h-full overflow-hidden">
+      <div className="hidden md:flex flex-col w-80 flex-shrink-0 border-r bg-background h-full overflow-hidden">
         <div className="flex items-center gap-1 border-b px-4 py-3">
-          <h2 className="text-base font-semibold flex-1">Filters</h2>
+          <h2 className="text-base font-semibold flex-1">💥CrashMap</h2>
           <Button variant="ghost" size="icon" onClick={onTogglePin} aria-label="Unpin panel">
             <PinOff className="size-4" />
           </Button>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close filters">
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
             <X className="size-4" />
           </Button>
         </div>
-        <div className="flex-1 overflow-y-auto">
-          <FilterContent />
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          <InfoPanelContent />
         </div>
       </div>
     )
@@ -51,12 +35,12 @@ export function Sidebar({ pinned, onClose, onTogglePin, isOpen }: SidebarProps) 
   return (
     <Sheet open={isOpen ?? false} onOpenChange={(open) => !open && onClose()}>
       <SheetContent
-        side="right"
+        side="left"
         className="w-80 sm:max-w-80 flex flex-col gap-0"
         showCloseButton={false}
       >
         <div className="flex items-center gap-1 border-b px-4 py-3">
-          <SheetTitle className="flex-1">Filters</SheetTitle>
+          <SheetTitle className="flex-1">💥CrashMap</SheetTitle>
           <Button
             variant="ghost"
             size="icon"
@@ -67,13 +51,13 @@ export function Sidebar({ pinned, onClose, onTogglePin, isOpen }: SidebarProps) 
             <Pin className="size-4" />
           </Button>
           <SheetClose asChild>
-            <Button variant="ghost" size="icon" aria-label="Close filters">
+            <Button variant="ghost" size="icon" aria-label="Close">
               <X className="size-4" />
             </Button>
           </SheetClose>
         </div>
-        <div className="flex-1 overflow-y-auto">
-          <FilterContent />
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          <InfoPanelContent />
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
- Added `components/info/InfoPanelContent.tsx` — content for the About panel: a dedication, data description (with link to the WSDOT Crash Data Portal), a map key showing severity color legend, a data disclaimer, and a "Get Involved" list of bicycle/pedestrian safety and advocacy resources
- Added `components/info/InfoOverlay.tsx` — mobile full-screen About overlay (mirrors `FilterOverlay`, hidden on desktop via `md:hidden`)
- Added `components/info/InfoSidePanel.tsx` — desktop About panel with two rendering modes: Sheet (slides from left, with Pin button) and pinned div (flex column, with PinOff + Close buttons)
- Modified `components/sidebar/Sidebar.tsx` — added pinnable mode: Sheet renders with a Pin button; pinned renders as a flex column with PinOff + Close header; `showCloseButton={false}` so the custom header owns both actions consistently
- Refactored `components/layout/AppShell.tsx` — outer flex container so pinned panels push the map rather than overlaying it; `sidebarOpen`/`sidebarPinned`/`infoPanelOpen`/`infoPanelPinned` state; both panels default to open + pinned on desktop; `map.resize()` fires on all panel state changes; Info button added to top-left
- Changed favicon to 💥 emoji via inline SVG data URI in `app/layout.tsx` metadata

Closes #109 