### PR TITLE
Summary Bar Redesign and Emoji Mode Badges

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -933,4 +933,17 @@ const themes = {
 }
 ```
 
+## 10. Screen Reader Navigation
+
+### Concept
+
+- To be able to navigate the map using a screen reader using directional commands.
+- Broadly, the user will give an address, city, or city and neighborhood. Using an AI tool, a description of the location will be read. They will then will be able to navigate the map with arrow keys or "move north, move east, move west, move south" commands. With each movement, the next closest crash/neighborhood/city will be selected, the movement to the new location is described (how far, direction), an AI description of the streetscape is read, and the full details of that crash/neighborhood/city will be read. Further directional commands can be given, or an options menu can be opened. If options selected, the user can change mode (crash/neighborhood/city) or adjust filters, etc. Streetscape description can be turned on or off, or switched between detailed and brief descriptions.
+
+- Example Detailed prompt: For the purposes of describing a streetscape for a blind person, using online searches and street view tools: describe in a few sentences: the corner of Pine St and Boren St, Capitol Hill, Seattle, WA.
+- Example Brief prompt: For the purposes of describing a streetscape for a blind person, using online searches and street view tools: very quickly describe in one or two sentences: the corner of Pine St and Boren St, Capitol Hill, Seattle, WA.
+- Possible travel prompt:For the purposes of describing in-detail a hypothetical journey on foot for a blind person, using online searches and street view tools: describe in a few sentences: travel from Location 1 to Location 2. Include the distance of journey. Include whether the journey would be plausible or safe.
+- Location 1: Broadway and E Jefferson St, Seattle, WA, coordinates: 47.60619663739793, -122.32079494873855
+- Location 2: Broadway and E Fir St, Seattle, WA, coordinates of 47.602701919984966, -122.32077733634235
+
 ---

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-20 — Summary Bar Redesign and Emoji Mode Badges
+
+- `SummaryBar` mobile layout changed to a fixed full-width strip flush against the viewport bottom (`fixed bottom-0 left-0 right-0`), minimal height, no rounded corners; desktop changed to a `rounded-md` bar close to the bottom edge (`bottom-3`) with tighter padding
+- Crash count removed from `SummaryBar`; moved to the top of `FilterContent` in `Sidebar` and to the header of `FilterOverlay`
+- Export button hidden on mobile in `SummaryBar` (desktop-only via `hidden md:flex`)
+- `getActiveFilterLabels` updated: mode now shows emoji(s) (🚲, 🚶🏽‍♀️, or both) instead of text; year shortened to `'25` format; state label removed (only Washington data); county omitted when a city is also selected
+
 ### 2026-02-20 — About Panel, Pinnable Panels, and Emoji Favicon
 
 - Added `components/info/InfoPanelContent.tsx` — content for the About panel: a dedication, data description (with link to the WSDOT Crash Data Portal), a map key showing severity color legend, a data disclaimer, and a "Get Involved" list of bicycle/pedestrian safety and advocacy resources

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -122,7 +122,6 @@ export function AppShell() {
         </div>
 
         <SummaryBar
-          crashCount={filterState.totalCount}
           activeFilters={getActiveFilterLabels(filterState)}
           isLoading={filterState.isLoading}
           actions={<ExportButton variant="icon" />}

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -7,6 +7,7 @@ import { SeverityFilter } from '@/components/filters/SeverityFilter'
 import { DateFilter } from '@/components/filters/DateFilter'
 import { GeographicFilter } from '@/components/filters/GeographicFilter'
 import { ExportButton } from '@/components/export/ExportButton'
+import { useFilterContext } from '@/context/FilterContext'
 
 interface FilterOverlayProps {
   isOpen: boolean
@@ -14,6 +15,7 @@ interface FilterOverlayProps {
 }
 
 export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
+  const { filterState } = useFilterContext()
   if (!isOpen) return null
 
   return (
@@ -24,7 +26,14 @@ export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
       aria-label="Filters"
     >
       <div className="flex items-center justify-between border-b px-4 py-3">
-        <h2 className="text-base font-semibold">Filters</h2>
+        <div>
+          <h2 className="text-base font-semibold">Filters</h2>
+          {filterState.totalCount !== null && (
+            <p className="text-xs text-muted-foreground">
+              {filterState.totalCount.toLocaleString()} crashes
+            </p>
+          )}
+        </div>
         <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close filters">
           <X className="size-4" />
         </Button>

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import { SeverityFilter } from '@/components/filters/SeverityFilter'
 import { DateFilter } from '@/components/filters/DateFilter'
 import { GeographicFilter } from '@/components/filters/GeographicFilter'
 import { ExportButton } from '@/components/export/ExportButton'
+import { useFilterContext } from '@/context/FilterContext'
 
 interface SidebarProps {
   pinned: boolean
@@ -17,8 +18,14 @@ interface SidebarProps {
 }
 
 function FilterContent() {
+  const { filterState } = useFilterContext()
   return (
     <div className="space-y-6 px-4 py-4">
+      {filterState.totalCount !== null && (
+        <p className="text-sm text-muted-foreground">
+          {filterState.totalCount.toLocaleString()} crashes
+        </p>
+      )}
       <ModeToggle />
       <DateFilter />
       <SeverityFilter />

--- a/components/summary/SummaryBar.tsx
+++ b/components/summary/SummaryBar.tsx
@@ -3,59 +3,41 @@
 import React from 'react'
 import { Loader2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
-import { Skeleton } from '@/components/ui/skeleton'
 
 interface SummaryBarProps {
-  crashCount?: number | null
   activeFilters?: string[]
   isLoading?: boolean
   actions?: React.ReactNode
 }
 
-export function SummaryBar({
-  crashCount = null,
-  activeFilters = [],
-  isLoading = false,
-  actions,
-}: SummaryBarProps) {
-  const countLabel = crashCount === null ? '—' : crashCount.toLocaleString()
-
+export function SummaryBar({ activeFilters = [], isLoading = false, actions }: SummaryBarProps) {
   return (
     <div
-      className="absolute bottom-6 left-1/2 z-10 flex -translate-x-1/2 items-center gap-3 rounded-full border bg-background/90 px-4 py-2 shadow-md backdrop-blur-sm"
+      // Mobile: fixed strip flush against the viewport bottom, full width, minimal height.
+      // Desktop: floating centered pill above the bottom edge of the map area.
+      className="fixed bottom-0 left-0 right-0 z-10 flex items-center gap-2 border-t bg-background/90 px-3 py-1.5 shadow-sm backdrop-blur-sm md:absolute md:bottom-3 md:left-1/2 md:right-auto md:w-auto md:-translate-x-1/2 md:rounded-md md:border md:px-4 md:py-1 md:shadow-md"
       role="status"
       aria-live="polite"
       aria-label="Summary"
     >
-      <span className="flex items-center gap-1.5 text-sm font-medium tabular-nums whitespace-nowrap">
-        {isLoading && <Loader2 className="size-3 animate-spin" aria-hidden="true" />}
-        {crashCount === null ? (
-          <>
-            <Skeleton className="inline-block h-4 w-10 align-middle" /> crashes
-          </>
-        ) : (
-          <span className={isLoading ? 'animate-pulse' : ''}>{countLabel} crashes</span>
-        )}
-      </span>
+      {isLoading && <Loader2 className="size-3 shrink-0 animate-spin" aria-hidden="true" />}
 
       {activeFilters.length > 0 && (
-        <>
-          <div className="h-4 w-px bg-border" aria-hidden="true" />
-          <div className="flex flex-wrap gap-1.5">
-            {activeFilters.map((filter) => (
-              <Badge key={filter} variant="secondary" className="text-xs">
-                {filter}
-              </Badge>
-            ))}
-          </div>
-        </>
+        <div className="flex flex-wrap gap-1.5">
+          {activeFilters.map((filter) => (
+            <Badge key={filter} variant="secondary" className="text-xs">
+              {filter}
+            </Badge>
+          ))}
+        </div>
       )}
 
+      {/* Actions (e.g. export button) — desktop only */}
       {actions && (
-        <>
+        <div className="hidden md:flex items-center gap-1 ml-auto">
           <div className="h-4 w-px bg-border" aria-hidden="true" />
           {actions}
-        </>
+        </div>
       )}
     </div>
   )

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -191,7 +191,14 @@ export function toCrashFilter(filterState: FilterState): CrashFilterInput {
 export function getActiveFilterLabels(filterState: FilterState): string[] {
   const labels: string[] = []
 
-  labels.push(filterState.mode ? filterState.mode + 's' : 'All modes')
+  // Mode: use emoji(s) instead of text
+  if (filterState.mode === 'Bicyclist') {
+    labels.push('🚲')
+  } else if (filterState.mode === 'Pedestrian') {
+    labels.push('🚶🏽‍♀️')
+  } else {
+    labels.push('🚲 🚶🏽‍♀️')
+  }
 
   // Only flag severity when it differs from the default three-bucket set.
   const defaultSet = new Set<string>(DEFAULT_SEVERITY)
@@ -206,14 +213,15 @@ export function getActiveFilterLabels(filterState: FilterState): string[] {
     labels.push(all.length === 0 ? 'No severity' : all.join(' + '))
   }
 
+  // Date: shorten year to '25 format; omit state (only Washington data available)
   if (filterState.dateFilter.type === 'year') {
-    labels.push(String(filterState.dateFilter.year))
+    labels.push(`'${String(filterState.dateFilter.year).slice(2)}`)
   } else if (filterState.dateFilter.type === 'range') {
     labels.push(`${filterState.dateFilter.startDate} – ${filterState.dateFilter.endDate}`)
   }
 
-  if (filterState.state) labels.push(filterState.state)
-  if (filterState.county) labels.push(filterState.county)
+  // Geographic: skip state label; show county only if no city is selected
+  if (!filterState.city && filterState.county) labels.push(filterState.county)
   if (filterState.city) labels.push(filterState.city)
 
   return labels


### PR DESCRIPTION
- `SummaryBar` mobile layout changed to a fixed full-width strip flush against the viewport bottom (`fixed bottom-0 left-0 right-0`), minimal height, no rounded corners; desktop changed to a `rounded-md` bar close to the bottom edge (`bottom-3`) with tighter padding
- Crash count removed from `SummaryBar`; moved to the top of `FilterContent` in `Sidebar` and to the header of `FilterOverlay`
- Export button hidden on mobile in `SummaryBar` (desktop-only via `hidden md:flex`)
- `getActiveFilterLabels` updated: mode now shows emoji(s) (🚲, 🚶🏽‍♀️, or both) instead of text; year shortened to `'25` format; state label removed (only Washington data); county omitted when a city is also selected

Closes #128 