### PR TITLE
Update Search as Map Moves, Decoupled Location Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-23 — Update Search as Map Moves, Decoupled Location Filters
+
+- Added "Update search as map moves" toggle in the Map Controls section of the filter panel; when on, the crash query uses the current viewport bounding box instead of state/county/city text filters
+- Map pans and zooms trigger a new query on `moveend`; previous dots stay visible during loading (Apollo `previousData`) so there is no flash-to-empty on each movement
+- Viewport bbox computed by unprojecting canvas corner pixels via `map.unproject()` rather than `map.getBounds()`, which ignores camera padding from prior `fitBounds` calls; bbox includes a 5% buffer beyond the canvas edges
+- Auto-zoom on geographic filter change is suppressed while "update with movement" is active (map position is user-driven)
+- Removed the State selector from the Location filter (all data is from Washington)
+- Decoupled County and City: either can be selected independently without resetting the other; both dropdowns load all Washington options regardless of the other's value
+- `?movement=1` URL param added to `filterUrlState` encode/decode for shareable movement-mode links
+- Active filter badge shows "📍 Viewport" when movement mode is on
+
 ### 2026-02-23 — Popup Viewport Centering
 
 - Clicking a crash now animates the map to zoom in (zoom 15.5) and tilt (pitch 45°) on the crash location via `map.flyTo()`

--- a/components/filters/GeographicFilter.tsx
+++ b/components/filters/GeographicFilter.tsx
@@ -9,13 +9,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useFilterContext } from '@/context/FilterContext'
 import {
-  GET_FILTER_OPTIONS,
   GET_COUNTIES,
   GET_CITIES,
-  type GetFilterOptionsQuery,
   type GetCountiesQuery,
   type GetCitiesQuery,
 } from '@/lib/graphql/queries'
@@ -23,32 +23,27 @@ import {
 // Sentinel value used instead of empty string (shadcn Select doesn't support null values).
 const ALL = '__all__'
 
+// Washington is the only state in the dataset — hardcode it for all county/city queries.
+const WASHINGTON = 'Washington'
+
 export function GeographicFilter() {
   const { filterState, dispatch } = useFilterContext()
 
-  const { data: optionsData, loading: optionsLoading } =
-    useQuery<GetFilterOptionsQuery>(GET_FILTER_OPTIONS)
-
+  // Always load all counties for Washington (no state selector in UI).
   const { data: countiesData, loading: countiesLoading } = useQuery<GetCountiesQuery>(
     GET_COUNTIES,
-    {
-      variables: { state: filterState.state },
-      skip: !filterState.state,
-    }
+    { variables: { state: WASHINGTON } }
   )
 
+  // Always load all cities for Washington — decoupled from county selection.
   const { data: citiesData, loading: citiesLoading } = useQuery<GetCitiesQuery>(GET_CITIES, {
-    variables: { state: filterState.state, county: filterState.county },
-    skip: !filterState.county,
+    variables: { state: WASHINGTON },
   })
 
-  const states = optionsData?.filterOptions?.states ?? []
   const counties = countiesData?.filterOptions?.counties ?? []
   const cities = citiesData?.filterOptions?.cities ?? []
 
-  function handleStateChange(value: string) {
-    dispatch({ type: 'SET_STATE', payload: value === ALL ? null : value })
-  }
+  const isDisabled = filterState.updateWithMovement
 
   function handleCountyChange(value: string) {
     dispatch({ type: 'SET_COUNTY', payload: value === ALL ? null : value })
@@ -58,75 +53,89 @@ export function GeographicFilter() {
     dispatch({ type: 'SET_CITY', payload: value === ALL ? null : value })
   }
 
-  if (optionsLoading) {
+  function handleMovementToggle(checked: boolean) {
+    dispatch({ type: 'SET_UPDATE_WITH_MOVEMENT', payload: checked })
+  }
+
+  if (countiesLoading && citiesLoading && !countiesData && !citiesData) {
     return (
-      <div className="space-y-2">
-        <p className="text-sm font-medium">Location</p>
-        <Skeleton className="h-9 w-full" />
-        <Skeleton className="h-9 w-full" />
-        <Skeleton className="h-9 w-full" />
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Location</p>
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-full" />
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-1.5">
-        <p className="text-sm font-medium">Location</p>
-        {(countiesLoading || citiesLoading) && (
-          <Loader2 className="size-3 animate-spin text-muted-foreground" aria-label="Loading" />
-        )}
+    <div className="space-y-4">
+      {/* Location selectors */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-1.5">
+          <p className="text-sm font-medium">Location</p>
+          {(countiesLoading || citiesLoading) && (
+            <Loader2 className="size-3 animate-spin text-muted-foreground" aria-label="Loading" />
+          )}
+        </div>
+
+        <Select
+          value={filterState.county ?? ALL}
+          onValueChange={handleCountyChange}
+          disabled={isDisabled || counties.length === 0}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="All counties" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All counties</SelectItem>
+            {counties.map((c) => (
+              <SelectItem key={c} value={c}>
+                {c}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filterState.city ?? ALL}
+          onValueChange={handleCityChange}
+          disabled={isDisabled || cities.length === 0}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="All cities" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All cities</SelectItem>
+            {cities.map((c) => (
+              <SelectItem key={c} value={c}>
+                {c}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      <Select value={filterState.state ?? ALL} onValueChange={handleStateChange}>
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder="All states" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={ALL}>All states</SelectItem>
-          {states.map((s) => (
-            <SelectItem key={s} value={s}>
-              {s}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      <Select
-        value={filterState.county ?? ALL}
-        onValueChange={handleCountyChange}
-        disabled={!filterState.state || counties.length === 0}
-      >
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder="All counties" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={ALL}>All counties</SelectItem>
-          {counties.map((c) => (
-            <SelectItem key={c} value={c}>
-              {c}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      <Select
-        value={filterState.city ?? ALL}
-        onValueChange={handleCityChange}
-        disabled={!filterState.county || cities.length === 0}
-      >
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder="All cities" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={ALL}>All cities</SelectItem>
-          {cities.map((c) => (
-            <SelectItem key={c} value={c}>
-              {c}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      {/* Map Controls */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Map Controls</p>
+        <div className="flex items-center gap-2">
+          <Switch
+            id="update-with-movement"
+            checked={filterState.updateWithMovement}
+            onCheckedChange={handleMovementToggle}
+          />
+          <Label htmlFor="update-with-movement" className="text-sm cursor-pointer">
+            Update search as map moves
+          </Label>
+        </div>
+        {filterState.updateWithMovement && (
+          <p className="text-xs text-muted-foreground">
+            Showing crashes within the current viewport. Pan or zoom to update results.
+          </p>
+        )}
+      </div>
     </div>
   )
 }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import * as React from 'react'
+import { Label as LabelPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import * as React from 'react'
+import { Switch as SwitchPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Switch({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: 'sm' | 'default'
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6',
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0'
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/lib/filterUrlState.ts
+++ b/lib/filterUrlState.ts
@@ -10,6 +10,7 @@ export type UrlFilterState = {
   state: string | null
   county: string | null
   city: string | null
+  updateWithMovement: boolean
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -68,12 +69,17 @@ export function encodeFilterParams(filterState: FilterState): URLSearchParams {
     params.set('state', filterState.state === null ? 'none' : filterState.state)
   }
 
-  // county/city — omit when null
+  // county/city — omit when null (decoupled: neither depends on the other)
   if (filterState.county !== null) {
     params.set('county', filterState.county)
   }
   if (filterState.city !== null) {
     params.set('city', filterState.city)
+  }
+
+  // updateWithMovement — omit when false (the default)
+  if (filterState.updateWithMovement) {
+    params.set('movement', '1')
   }
 
   return params
@@ -136,13 +142,15 @@ export function decodeFilterParams(params: URLSearchParams): UrlFilterState {
     state = rawState === 'none' ? null : rawState
   }
 
-  // county: only set if state is non-null (guard orphan params)
+  // county/city: decoupled — each can be set independently
   const rawCounty = params.get('county')
-  const county: string | null = rawCounty !== null && state !== null ? rawCounty : null
+  const county: string | null = rawCounty !== null ? rawCounty : null
 
-  // city: only set if county is non-null
   const rawCity = params.get('city')
-  const city: string | null = rawCity !== null && county !== null ? rawCity : null
+  const city: string | null = rawCity !== null ? rawCity : null
 
-  return { mode, severity, includeNoInjury, dateFilter, state, county, city }
+  // updateWithMovement
+  const updateWithMovement = params.get('movement') === '1'
+
+  return { mode, severity, includeNoInjury, dateFilter, state, county, city, updateWithMovement }
 }


### PR DESCRIPTION
- Added "Update search as map moves" toggle in the Map Controls section of the filter panel; when on, the crash query uses the current viewport bounding box instead of state/county/city text filters
- Map pans and zooms trigger a new query on `moveend`; previous dots stay visible during loading (Apollo `previousData`) so there is no flash-to-empty on each movement
- Viewport bbox computed by unprojecting canvas corner pixels via `map.unproject()` rather than `map.getBounds()`, which ignores camera padding from prior `fitBounds` calls; bbox includes a 5% buffer beyond the canvas edges
- Auto-zoom on geographic filter change is suppressed while "update with movement" is active (map position is user-driven)
- Removed the State selector from the Location filter (all data is from Washington)
- Decoupled County and City: either can be selected independently without resetting the other; both dropdowns load all Washington options regardless of the other's value
- `?movement=1` URL param added to `filterUrlState` encode/decode for shareable movement-mode links
- Active filter badge shows "📍 Viewport" when movement mode is on

Closes #132