### PR TITLE
Satellite Map, Apple Maps Link, Popup Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-23 — Satellite Map, Apple Maps Link, Popup Refactor
+
+- Added "Satellite view" Switch toggle to the Map Controls section in the filter panel; when on, the map uses `mapbox://styles/mapbox/satellite-streets-v12` regardless of dark/light theme
+- Dot opacity reduced by 10% across all severity layers when satellite view is active (e.g. Death: 0.85 → 0.75) to maintain visual contrast against aerial imagery
+- Added "Open in Apple Maps" link to the crash detail popup above the existing Google Street View link; uses `https://maps.apple.com/?ll={lat},{lng}&z=20` (opens native Maps app on iOS/macOS)
+- Extracted crash popup into its own `components/map/CrashPopup.tsx` component; exports `SelectedCrash` type; owns `copied` state internally; `MapContainer` now renders `<CrashPopup crash={selectedCrash} onClose={closePopup} />`
+
 ### 2026-02-23 — CI/CD Pipeline and Staging Environment
 
 - Added `crashmap-staging` Render web service tracking the `staging` branch; auto-deploys on every push to `staging`

--- a/components/filters/GeographicFilter.tsx
+++ b/components/filters/GeographicFilter.tsx
@@ -57,6 +57,10 @@ export function GeographicFilter() {
     dispatch({ type: 'SET_UPDATE_WITH_MOVEMENT', payload: checked })
   }
 
+  function handleSatelliteToggle(checked: boolean) {
+    dispatch({ type: 'SET_SATELLITE', payload: checked })
+  }
+
   if (countiesLoading && citiesLoading && !countiesData && !citiesData) {
     return (
       <div className="space-y-4">
@@ -135,6 +139,16 @@ export function GeographicFilter() {
             Showing crashes within the current viewport. Pan or zoom to update results.
           </p>
         )}
+        <div className="flex items-center gap-2">
+          <Switch
+            id="satellite-view"
+            checked={filterState.satellite}
+            onCheckedChange={handleSatelliteToggle}
+          />
+          <Label htmlFor="satellite-view" className="text-sm cursor-pointer">
+            Satellite view
+          </Label>
+        </div>
       </div>
     </div>
   )

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -30,61 +30,64 @@ type GetCrashesQuery = {
   }
 }
 
-// Layers are rendered bottom-to-top: None → Minor → Major → Death
-// so higher-severity dots always appear on top of lower-severity ones.
-const noneLayer: LayerProps = {
-  id: 'crashes-none',
-  type: 'circle',
-  filter: ['==', ['get', 'severity'], 'None'],
-  paint: {
-    'circle-color': '#C5E1A5',
-    'circle-opacity': 0.5,
-    'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 1, 10, 5, 15, 9],
-    'circle-stroke-width': 0,
-  },
-}
-
-const minorLayer: LayerProps = {
-  id: 'crashes-minor',
-  type: 'circle',
-  filter: ['==', ['get', 'severity'], 'Minor Injury'],
-  paint: {
-    'circle-color': '#FDD835',
-    'circle-opacity': 0.55,
-    'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 1.5, 10, 6, 15, 12],
-    'circle-stroke-width': 0,
-  },
-}
-
-const majorLayer: LayerProps = {
-  id: 'crashes-major',
-  type: 'circle',
-  filter: ['==', ['get', 'severity'], 'Major Injury'],
-  paint: {
-    'circle-color': '#F57C00',
-    'circle-opacity': 0.7,
-    'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 2, 10, 7, 15, 15],
-    'circle-stroke-width': 0,
-  },
-}
-
-const deathLayer: LayerProps = {
-  id: 'crashes-death',
-  type: 'circle',
-  filter: ['==', ['get', 'severity'], 'Death'],
-  paint: {
-    'circle-color': '#B71C1C',
-    'circle-opacity': 0.85,
-    'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 2.5, 10, 8, 15, 18],
-    'circle-stroke-width': 0,
-  },
-}
-
 const ALL_LAYER_IDS = ['crashes-none', 'crashes-minor', 'crashes-major', 'crashes-death']
 
 export function CrashLayer() {
   const { current: map } = useMap()
   const { filterState, dispatch } = useFilterContext()
+
+  // Reduce dot opacity by 10% on satellite to maintain visibility against imagery.
+  const opacityOffset = filterState.satellite ? 0.1 : 0
+
+  // Layers are rendered bottom-to-top: None → Minor → Major → Death
+  // so higher-severity dots always appear on top of lower-severity ones.
+  const noneLayer: LayerProps = {
+    id: 'crashes-none',
+    type: 'circle',
+    filter: ['==', ['get', 'severity'], 'None'],
+    paint: {
+      'circle-color': '#C5E1A5',
+      'circle-opacity': 0.5 + opacityOffset,
+      'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 1, 10, 5, 15, 9],
+      'circle-stroke-width': 0,
+    },
+  }
+
+  const minorLayer: LayerProps = {
+    id: 'crashes-minor',
+    type: 'circle',
+    filter: ['==', ['get', 'severity'], 'Minor Injury'],
+    paint: {
+      'circle-color': '#FDD835',
+      'circle-opacity': 0.55 + opacityOffset,
+      'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 1.5, 10, 6, 15, 12],
+      'circle-stroke-width': 0,
+    },
+  }
+
+  const majorLayer: LayerProps = {
+    id: 'crashes-major',
+    type: 'circle',
+    filter: ['==', ['get', 'severity'], 'Major Injury'],
+    paint: {
+      'circle-color': '#F57C00',
+      'circle-opacity': 0.7 + opacityOffset,
+      'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 2, 10, 7, 15, 15],
+      'circle-stroke-width': 0,
+    },
+  }
+
+  const deathLayer: LayerProps = {
+    id: 'crashes-death',
+    type: 'circle',
+    filter: ['==', ['get', 'severity'], 'Death'],
+    paint: {
+      'circle-color': '#B71C1C',
+      'circle-opacity': 0.85 + opacityOffset,
+      'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 2.5, 10, 8, 15, 18],
+      'circle-stroke-width': 0,
+    },
+  }
 
   // Viewport bbox — only used when updateWithMovement is on.
   type BBox = NonNullable<CrashFilterInput['bbox']>

--- a/components/map/CrashPopup.tsx
+++ b/components/map/CrashPopup.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Popup } from 'react-map-gl/mapbox'
+import { Check, Copy } from 'lucide-react'
+
+export type SelectedCrash = {
+  longitude: number
+  latitude: number
+  colliRptNum: string | null
+  severity: string | null
+  injuryType: string | null
+  mode: string | null
+  crashDate: string | null
+  time: string | null
+  involvedPersons: number | null
+  city: string | null
+  county: string | null
+  jurisdiction: string | null
+}
+
+const SEVERITY_COLORS: Record<string, string> = {
+  Death: '#B71C1C',
+  'Major Injury': '#F57C00',
+  'Minor Injury': '#FDD835',
+  None: '#C5E1A5',
+}
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+type CrashPopupProps = {
+  crash: SelectedCrash
+  onClose: () => void
+}
+
+export function CrashPopup({ crash, onClose }: CrashPopupProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyReportNum = useCallback((num: string) => {
+    navigator.clipboard.writeText(num)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [])
+
+  return (
+    <Popup
+      longitude={crash.longitude}
+      latitude={crash.latitude}
+      onClose={onClose}
+      closeButton
+      closeOnClick={false}
+      anchor="bottom"
+      offset={10}
+      maxWidth="220px"
+    >
+      <div className="px-1 py-1.5 text-[13px] leading-relaxed">
+        {crash.crashDate && (
+          <div className="mb-0.5 font-semibold">{formatDate(crash.crashDate)}</div>
+        )}
+        {crash.time && (
+          <div className="mb-1" style={{ color: 'var(--muted-foreground)' }}>
+            {crash.time}
+          </div>
+        )}
+        {(crash.severity || crash.injuryType) && (
+          <div className="flex items-center gap-1.5">
+            <span
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: '50%',
+                backgroundColor: crash.severity
+                  ? (SEVERITY_COLORS[crash.severity] ?? '#999')
+                  : '#999',
+                flexShrink: 0,
+                border: '1px solid rgba(0,0,0,0.15)',
+              }}
+            />
+            {crash.injuryType ?? crash.severity}
+          </div>
+        )}
+        {crash.mode && <div>{crash.mode}</div>}
+        {(crash.city || crash.county) && (
+          <div style={{ color: 'var(--muted-foreground)' }}>
+            {[crash.city, crash.county].filter(Boolean).join(', ')}
+          </div>
+        )}
+        {crash.jurisdiction && (
+          <div style={{ color: 'var(--muted-foreground)' }}>{crash.jurisdiction}</div>
+        )}
+        {crash.involvedPersons != null && (
+          <div style={{ color: 'var(--muted-foreground)' }}>{crash.involvedPersons} involved</div>
+        )}
+        {crash.colliRptNum && (
+          <div
+            className="mt-1 flex items-center gap-1 text-[11px]"
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            <span>
+              Report #:{' '}
+              <a
+                href="https://wrecr.wsp.wa.gov/wrecr/order"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--muted-foreground)', textDecoration: 'underline' }}
+              >
+                {crash.colliRptNum}
+              </a>
+            </span>
+            <button
+              onClick={() => handleCopyReportNum(crash.colliRptNum!)}
+              title="Copy report number"
+              style={{ color: 'var(--muted-foreground)', lineHeight: 1 }}
+            >
+              {copied ? <Check size={11} /> : <Copy size={11} />}
+            </button>
+          </div>
+        )}
+        <div
+          className="mt-2 border-t pt-1.5 flex flex-col gap-1"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          <a
+            href={`https://maps.apple.com/?ll=${crash.latitude},${crash.longitude}&z=20`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px]"
+            style={{ color: 'var(--primary)', textDecoration: 'underline' }}
+          >
+            Open in Apple Maps
+          </a>
+          <a
+            href={`https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${crash.latitude},${crash.longitude}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px]"
+            style={{ color: 'var(--primary)', textDecoration: 'underline' }}
+          >
+            Open Street View
+          </a>
+        </div>
+      </div>
+    </Popup>
+  )
+}

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -21,6 +21,7 @@ export interface FilterState {
   county: string | null
   city: string | null
   updateWithMovement: boolean // when true, query uses viewport bbox instead of geo text filters
+  satellite: boolean // when true, map uses satellite-streets style regardless of theme
   totalCount: number | null // populated by CrashLayer after query
   isLoading: boolean // true while a filter-triggered refetch is in flight
 }
@@ -48,6 +49,7 @@ export type FilterAction =
   | { type: 'SET_COUNTY'; payload: string | null }
   | { type: 'SET_CITY'; payload: string | null }
   | { type: 'SET_UPDATE_WITH_MOVEMENT'; payload: boolean }
+  | { type: 'SET_SATELLITE'; payload: boolean }
   | { type: 'SET_TOTAL_COUNT'; payload: number | null }
   | { type: 'SET_LOADING'; payload: boolean }
   | { type: 'RESET' }
@@ -80,6 +82,7 @@ const initialState: FilterState = {
   county: null,
   city: null,
   updateWithMovement: false,
+  satellite: false,
   totalCount: null,
   isLoading: false,
 }
@@ -117,6 +120,8 @@ function filterReducer(filterState: FilterState, action: FilterAction): FilterSt
       return { ...filterState, city: action.payload }
     case 'SET_UPDATE_WITH_MOVEMENT':
       return { ...filterState, updateWithMovement: action.payload }
+    case 'SET_SATELLITE':
+      return { ...filterState, satellite: action.payload }
     case 'SET_TOTAL_COUNT':
       return { ...filterState, totalCount: action.payload }
     case 'SET_LOADING':


### PR DESCRIPTION
- Added "Satellite view" Switch toggle to the Map Controls section in the filter panel; when on, the map uses `mapbox://styles/mapbox/satellite-streets-v12` regardless of dark/light theme
- Dot opacity reduced by 10% across all severity layers when satellite view is active (e.g. Death: 0.85 → 0.75) to maintain visual contrast against aerial imagery
- Added "Open in Apple Maps" link to the crash detail popup above the existing Google Street View link; uses `https://maps.apple.com/?ll={lat},{lng}&z=20` (opens native Maps app on iOS/macOS)
- Extracted crash popup into its own `components/map/CrashPopup.tsx` component; exports `SelectedCrash` type; owns `copied` state internally; `MapContainer` now renders `<CrashPopup crash={selectedCrash} onClose={closePopup} />`

Closes #135 