### PR TITLE
Add Health Check Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Changelog
 
+### 2026-02-23 — Health Check Endpoint
+
+- Added `GET /api/health` route returning `200 {"status":"ok"}`; `force-dynamic` prevents static caching
+- Added `healthCheckPath: /api/health` to both `crashmap` and `crashmap-staging` services in `render.yaml`
+- Set **Health Check Path** to `/api/health` in Render dashboard (both services) → Health & Alerts
+
 ### 2026-02-23 — Satellite Map, Apple Maps Link, Popup Refactor
 
 - Added "Satellite view" Switch toggle to the Map Controls section in the filter panel; when on, the map uses `mapbox://styles/mapbox/satellite-streets-v12` regardless of dark/light theme

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic'
+
+export function GET() {
+  return Response.json({ status: 'ok' })
+}

--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
     runtime: node
     branch: main
     autoDeploy: false
+    healthCheckPath: /api/health
     buildCommand: >-
       npm ci && npm run build &&
       cp -r public .next/standalone/public &&
@@ -25,6 +26,7 @@ services:
     runtime: node
     branch: staging
     autoDeploy: true
+    healthCheckPath: /api/health
     buildCommand: >-
       npm ci && npm run build &&
       cp -r public .next/standalone/public &&


### PR DESCRIPTION
- Added `GET /api/health` route returning `200 {"status":"ok"}`; `force-dynamic` prevents static caching
- Added `healthCheckPath: /api/health` to both `crashmap` and `crashmap-staging` services in `render.yaml`
- Set **Health Check Path** to `/api/health` in Render dashboard (both services) → Health & Alerts

Closes #115 