### PR TITLE
Add Support Panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,21 @@
 # CrashMap
 
-**Version:** 0.5.4
+**Version:** 0.6.0
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
 This project was bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
-## Getting Started
-
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-
----
-
 ## Changelog
+
+### 2026-02-23 — Support Panel
+
+- Added Heart (❤) button to the top-left map controls, to the right of the existing Info button
+- Clicking it opens the left panel in a new "Support this App" view with hosting-costs blurb, PayPal/CashApp/Venmo donate links, and a contact link
+- "← Back to Info" and "❤️ Support this App" nav links let users switch views in-place without reopening the panel
+- Added shared `PanelCredit` component (author name + tagline) rendered at the top of both panel views
+- Added GitHub repo link to The Data section of the info panel
+- Fixed top map button dark-mode styling: solid `dark:bg-zinc-900 dark:border-zinc-700` instead of default semi-transparent border
 
 ### 2026-02-23 — Health Check Endpoint
 

--- a/components/info/InfoOverlay.tsx
+++ b/components/info/InfoOverlay.tsx
@@ -3,13 +3,17 @@
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { InfoPanelContent } from './InfoPanelContent'
+import { SupportPanelContent } from './SupportPanelContent'
+import type { InfoPanelView } from './InfoSidePanel'
 
 interface InfoOverlayProps {
   isOpen: boolean
   onClose: () => void
+  view?: InfoPanelView
+  onSwitchView?: (view: InfoPanelView) => void
 }
 
-export function InfoOverlay({ isOpen, onClose }: InfoOverlayProps) {
+export function InfoOverlay({ isOpen, onClose, view = 'info', onSwitchView }: InfoOverlayProps) {
   if (!isOpen) return null
 
   return (
@@ -27,7 +31,15 @@ export function InfoOverlay({ isOpen, onClose }: InfoOverlayProps) {
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 py-4">
-        <InfoPanelContent />
+        {view === 'support' ? (
+          <SupportPanelContent
+            onSwitchView={onSwitchView ? () => onSwitchView('info') : undefined}
+          />
+        ) : (
+          <InfoPanelContent
+            onSwitchView={onSwitchView ? () => onSwitchView('support') : undefined}
+          />
+        )}
       </div>
     </div>
   )

--- a/components/info/InfoPanelContent.tsx
+++ b/components/info/InfoPanelContent.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from 'lucide-react'
+import { PanelCredit } from './PanelCredit'
 
 const resources = [
   {
@@ -23,15 +24,14 @@ const resources = [
   },
 ]
 
-export function InfoPanelContent() {
+interface InfoPanelContentProps {
+  onSwitchView?: () => void
+}
+
+export function InfoPanelContent({ onSwitchView }: InfoPanelContentProps) {
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-base font-semibold">About</h2>
-        <p className="text-xs text-muted-foreground/60 mt-0.5">
-          Version 0.5.4 &middot; Updated 2/20/2026
-        </p>
-      </div>
+      <PanelCredit />
 
       <section>
         <p className="text-sm text-muted-foreground leading-relaxed">
@@ -62,7 +62,29 @@ export function InfoPanelContent() {
           </a>
           , which is compiled from police reports.
         </p>
+        <p className="text-sm text-muted-foreground leading-relaxed mt-3">
+          Find this project on{' '}
+          <a
+            href="https://github.com/nickmagruder/crashmap"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline inline-flex items-center gap-0.5"
+          >
+            GitHub
+            <ExternalLink className="size-3 flex-shrink-0" />
+          </a>
+          .
+        </p>
       </section>
+
+      {onSwitchView && (
+        <button
+          onClick={onSwitchView}
+          className="text-sm text-primary hover:underline flex items-center gap-1"
+        >
+          ❤️ Support this App
+        </button>
+      )}
 
       <section>
         <h3 className="text-sm font-semibold mb-3">Map Key</h3>
@@ -85,15 +107,6 @@ export function InfoPanelContent() {
       </section>
 
       <section>
-        <h3 className="text-sm font-semibold mb-2">Data Disclaimer</h3>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          This data is self-collected from publicly available state transportation department
-          records. It may be incomplete, contain errors, or not reflect the most recent crashes. It
-          should not be used as the sole basis for safety decisions or policy.
-        </p>
-      </section>
-
-      <section>
         <h3 className="text-sm font-semibold mb-2">📣 Get Involved!</h3>
         <ul className="space-y-2.5">
           {resources.map(({ href, label }) => (
@@ -110,6 +123,21 @@ export function InfoPanelContent() {
             </li>
           ))}
         </ul>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-semibold mb-2">Data Disclaimer</h3>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          This data is self-collected from publicly available state transportation department
+          records. It may be incomplete, contain errors, or not reflect the most recent crashes. It
+          should not be used as the sole basis for safety decisions or policy.
+        </p>
+      </section>
+      <section>
+        <p className="text-xs text-muted-foreground/60 mt-0.5">
+          Version 0.6.0 &middot; Updated 2/23/2026
+        </p>
+        <p className="text-xs text-muted-foreground/60 mt-0.5">© Copyright 2026 Nick Magruder</p>
       </section>
     </div>
   )

--- a/components/info/InfoSidePanel.tsx
+++ b/components/info/InfoSidePanel.tsx
@@ -4,20 +4,51 @@ import { Pin, PinOff, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetTitle, SheetClose } from '@/components/ui/sheet'
 import { InfoPanelContent } from './InfoPanelContent'
+import { SupportPanelContent } from './SupportPanelContent'
+
+export type InfoPanelView = 'info' | 'support'
 
 interface InfoSidePanelProps {
   pinned: boolean
   onClose: () => void
   onTogglePin: () => void
   isOpen?: boolean
+  view?: InfoPanelView
+  onSwitchView?: (view: InfoPanelView) => void
 }
 
-export function InfoSidePanel({ pinned, onClose, onTogglePin, isOpen }: InfoSidePanelProps) {
+const titles: Record<InfoPanelView, string> = {
+  info: '💥CrashMap',
+  support: '💥CrashMap',
+}
+
+function PanelBody({
+  view,
+  onSwitchView,
+}: {
+  view: InfoPanelView
+  onSwitchView?: (view: InfoPanelView) => void
+}) {
+  return view === 'support' ? (
+    <SupportPanelContent onSwitchView={onSwitchView ? () => onSwitchView('info') : undefined} />
+  ) : (
+    <InfoPanelContent onSwitchView={onSwitchView ? () => onSwitchView('support') : undefined} />
+  )
+}
+
+export function InfoSidePanel({
+  pinned,
+  onClose,
+  onTogglePin,
+  isOpen,
+  view = 'info',
+  onSwitchView,
+}: InfoSidePanelProps) {
   if (pinned) {
     return (
       <div className="hidden md:flex flex-col w-80 flex-shrink-0 border-r bg-background h-full overflow-hidden">
         <div className="flex items-center gap-1 border-b px-4 py-3">
-          <h2 className="text-base font-semibold flex-1">💥CrashMap</h2>
+          <h2 className="text-base font-semibold flex-1">{titles[view]}</h2>
           <Button variant="ghost" size="icon" onClick={onTogglePin} aria-label="Unpin panel">
             <PinOff className="size-4" />
           </Button>
@@ -26,7 +57,7 @@ export function InfoSidePanel({ pinned, onClose, onTogglePin, isOpen }: InfoSide
           </Button>
         </div>
         <div className="flex-1 overflow-y-auto px-4 py-4">
-          <InfoPanelContent />
+          <PanelBody view={view} onSwitchView={onSwitchView} />
         </div>
       </div>
     )
@@ -40,7 +71,7 @@ export function InfoSidePanel({ pinned, onClose, onTogglePin, isOpen }: InfoSide
         showCloseButton={false}
       >
         <div className="flex items-center gap-1 border-b px-4 py-3">
-          <SheetTitle className="flex-1">💥CrashMap</SheetTitle>
+          <SheetTitle className="flex-1">{titles[view]}</SheetTitle>
           <Button
             variant="ghost"
             size="icon"
@@ -57,7 +88,7 @@ export function InfoSidePanel({ pinned, onClose, onTogglePin, isOpen }: InfoSide
           </SheetClose>
         </div>
         <div className="flex-1 overflow-y-auto px-4 py-4">
-          <InfoPanelContent />
+          <PanelBody view={view} onSwitchView={onSwitchView} />
         </div>
       </SheetContent>
     </Sheet>

--- a/components/info/PanelCredit.tsx
+++ b/components/info/PanelCredit.tsx
@@ -1,0 +1,20 @@
+export function PanelCredit() {
+  return (
+    <div className="pb-4 border-b mb-6">
+      <p className="text-sm text-muted-foreground">
+        Created by{' '}
+        <a
+          href="https://www.magruder.info/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          Nick Magruder
+        </a>
+      </p>
+      <p className="text-xs text-muted-foreground/60 mt-0.5">
+        A former bike mechanic turned internet mechanic
+      </p>
+    </div>
+  )
+}

--- a/components/info/SupportPanelContent.tsx
+++ b/components/info/SupportPanelContent.tsx
@@ -1,0 +1,80 @@
+import { ExternalLink } from 'lucide-react'
+import { PanelCredit } from './PanelCredit'
+
+const paymentLinks = [
+  {
+    label: 'PayPal',
+    href: 'https://paypal.me/nickmagruder?locale.x=en_US&country.x=US',
+  },
+  {
+    label: 'CashApp',
+    href: 'https://cash.app/$iamnotatgregs',
+  },
+  {
+    label: 'Venmo',
+    href: 'https://venmo.com/u/NickMagruder',
+  },
+]
+
+interface SupportPanelContentProps {
+  onSwitchView?: () => void
+}
+
+export function SupportPanelContent({ onSwitchView }: SupportPanelContentProps) {
+  return (
+    <div className="space-y-6">
+      <PanelCredit />
+      {onSwitchView && (
+        <button
+          onClick={onSwitchView}
+          className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 -mt-3"
+        >
+          ← Back to Info
+        </button>
+      )}
+      <div>
+        <h2 className="text-base font-semibold">Support this App</h2>
+      </div>
+
+      <section>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          CrashMap is built and maintained in my spare time. Hosting and infrastructure costs come
+          out of pocket — the app is free and will always remain free. If you find it useful, any
+          support is genuinely appreciated, thank you!
+        </p>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-semibold mb-3">Donate</h3>
+        <ul className="space-y-3">
+          {paymentLinks.map(({ label, href }) => (
+            <li key={label}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-primary inline-flex items-center gap-1 hover:underline"
+              >
+                {label}
+                <ExternalLink className="size-3 flex-shrink-0" />
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-semibold mb-2">Contact</h3>
+        <a
+          href="https://www.magruder.info/contact/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-primary inline-flex items-center gap-1 hover:underline"
+        >
+          Get in touch
+          <ExternalLink className="size-3 flex-shrink-0" />
+        </a>
+      </section>
+    </div>
+  )
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { useRef, useEffect, useState } from 'react'
-import { Info, Loader2, SlidersHorizontal } from 'lucide-react'
+import { Heart, Info, Loader2, SlidersHorizontal } from 'lucide-react'
 import type { MapRef } from 'react-map-gl/mapbox'
 import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
 import { FilterOverlay } from '@/components/overlay/FilterOverlay'
-import { InfoSidePanel } from '@/components/info/InfoSidePanel'
+import { InfoSidePanel, type InfoPanelView } from '@/components/info/InfoSidePanel'
 import { InfoOverlay } from '@/components/info/InfoOverlay'
 import { SummaryBar } from '@/components/summary/SummaryBar'
 import { ExportButton } from '@/components/export/ExportButton'
@@ -33,6 +33,7 @@ export function AppShell() {
   const [infoPanelOpen, setInfoPanelOpen] = useState(true)
   const [infoPanelPinned, setInfoPanelPinned] = useState(true)
   const [infoOverlayOpen, setInfoOverlayOpen] = useState(false)
+  const [infoPanelView, setInfoPanelView] = useState<InfoPanelView>('info')
   const mapRef = useRef<MapRef>(null)
   const { filterState } = useFilterContext()
 
@@ -51,6 +52,8 @@ export function AppShell() {
           pinned
           onClose={() => setInfoPanelOpen(false)}
           onTogglePin={() => setInfoPanelPinned(false)}
+          view={infoPanelView}
+          onSwitchView={setInfoPanelView}
         />
       )}
 
@@ -60,40 +63,73 @@ export function AppShell() {
           <MapContainer ref={mapRef} />
         </ErrorBoundary>
 
-        {/* Top-left: info/about toggle */}
+        {/* Top-left: info/about toggle + support */}
         <div className="absolute top-4 left-4 z-10 flex gap-2">
           {/* Desktop version */}
-          <div className="hidden md:block">
+          <div className="hidden md:flex gap-2">
             <Button
               variant="outline"
               size="icon"
-              onClick={() => setInfoPanelOpen(true)}
+              className="dark:bg-zinc-900 dark:border-zinc-700"
+              onClick={() => {
+                setInfoPanelView('info')
+                setInfoPanelOpen(true)
+              }}
               aria-label="Open about panel"
             >
               <Info className="size-4" />
             </Button>
-          </div>
-          {/* Mobile version */}
-          <div className="md:hidden">
             <Button
               variant="outline"
               size="icon"
-              onClick={() => setInfoOverlayOpen(true)}
+              className="dark:bg-zinc-900 dark:border-zinc-700"
+              onClick={() => {
+                setInfoPanelView('support')
+                setInfoPanelOpen(true)
+              }}
+              aria-label="Support this app"
+            >
+              <Heart className="size-4" />
+            </Button>
+          </div>
+          {/* Mobile version */}
+          <div className="md:hidden flex gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              className="dark:bg-zinc-900 dark:border-zinc-700"
+              onClick={() => {
+                setInfoPanelView('info')
+                setInfoOverlayOpen(true)
+              }}
               aria-label="Open about"
             >
               <Info className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="dark:bg-zinc-900 dark:border-zinc-700"
+              onClick={() => {
+                setInfoPanelView('support')
+                setInfoOverlayOpen(true)
+              }}
+              aria-label="Support this app"
+            >
+              <Heart className="size-4" />
             </Button>
           </div>
         </div>
 
         {/* Top-right controls */}
         <div className="absolute top-4 right-4 z-10 flex gap-2">
-          <ThemeToggle />
+          <ThemeToggle className="dark:bg-zinc-900 dark:border-zinc-700" />
           {/* Sidebar toggle — desktop only */}
           <div className="hidden md:block">
             <Button
               variant="outline"
               size="icon"
+              className="dark:bg-zinc-900 dark:border-zinc-700"
               onClick={() => setSidebarOpen(true)}
               aria-label="Open filters"
             >
@@ -109,6 +145,7 @@ export function AppShell() {
             <Button
               variant="outline"
               size="icon"
+              className="dark:bg-zinc-900 dark:border-zinc-700"
               onClick={() => setOverlayOpen(true)}
               aria-label="Open filters"
             >
@@ -134,6 +171,8 @@ export function AppShell() {
             onClose={() => setInfoPanelOpen(false)}
             pinned={false}
             onTogglePin={() => setInfoPanelPinned(true)}
+            view={infoPanelView}
+            onSwitchView={setInfoPanelView}
           />
           {/* Desktop non-pinned filter panel (Sheet from right) */}
           <Sidebar
@@ -144,7 +183,12 @@ export function AppShell() {
           />
           {/* Mobile overlays */}
           <FilterOverlay isOpen={overlayOpen} onClose={() => setOverlayOpen(false)} />
-          <InfoOverlay isOpen={infoOverlayOpen} onClose={() => setInfoOverlayOpen(false)} />
+          <InfoOverlay
+            isOpen={infoOverlayOpen}
+            onClose={() => setInfoOverlayOpen(false)}
+            view={infoPanelView}
+            onSwitchView={setInfoPanelView}
+          />
         </ErrorBoundary>
       </div>
 

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -37,7 +37,7 @@ export function CrashLayer() {
   const { filterState, dispatch } = useFilterContext()
 
   // Reduce dot opacity by 10% on satellite to maintain visibility against imagery.
-  const opacityOffset = filterState.satellite ? 0.1 : 0
+  const opacityOffset = filterState.satellite ? 0.15 : 0
 
   // Layers are rendered bottom-to-top: None → Minor → Major → Death
   // so higher-severity dots always appear on top of lower-severity ones.

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -4,12 +4,13 @@ import { Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { Button } from '@/components/ui/button'
 
-export function ThemeToggle() {
+export function ThemeToggle({ className }: { className?: string }) {
   const { resolvedTheme, setTheme } = useTheme()
   return (
     <Button
       variant="outline"
       size="icon"
+      className={className}
       onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
       aria-label="Toggle theme"
     >

--- a/tutorial.md
+++ b/tutorial.md
@@ -5966,4 +5966,30 @@ Repeat for `crashmap-staging`.
 
 Render polls the health check path every 10 seconds. If it returns a non-2xx status three consecutive times, Render marks the service as unhealthy and alerts you. During a new deploy, Render waits for the health check to pass before shifting traffic to the new instance.
 
+---
+
+## Adding a Support Panel
+
+### Why
+
+A free public app still has hosting costs. Adding a visible but non-intrusive way for users to support the project is worthwhile — and it belongs in the UI, not buried in a README.
+
+### Approach: Multi-View Left Panel
+
+Rather than adding a third panel type, we reuse the existing left info panel and add a `view` prop (`'info' | 'support'`). A new Heart button in the top-left map controls opens the panel in `'support'` view; the original Info button opens it in `'info'` view. Both views share the same panel shell (header, pin/close buttons, scroll area) — only the content component swaps.
+
+View switching is managed in `AppShell` via `infoPanelView` state and an `onSwitchView` callback passed down to the content components. The content components render a "← Back to Info" or "❤️ Support this App" link that calls the callback, switching the view in-place without closing the panel.
+
+### Key files
+
+- `components/info/PanelCredit.tsx` — Shared author credit block (name + tagline), used at the top of both content views.
+- `components/info/SupportPanelContent.tsx` — Support view content: blurb, donate links, contact link.
+- `components/info/InfoSidePanel.tsx` — Extended with `view` and `onSwitchView` props; `PanelBody` helper selects the right content component.
+- `components/info/InfoOverlay.tsx` — Same extension for the mobile overlay.
+- `components/layout/AppShell.tsx` — Adds `infoPanelView` state; Heart button sets view to `'support'` and opens the panel; Info button sets it to `'info'`.
+
+### Dark-mode button fix
+
+The top map buttons use `variant="outline"` which picks up `border-input` in dark mode — `oklch(1 0 0 / 15%)`, a semi-transparent white that looks washed out over the map. Fix: add `className="dark:bg-zinc-900 dark:border-zinc-700"` to each button for a solid, clearly-defined appearance. `ThemeToggle` needed a one-line `className` prop added to pass the class through to the underlying `Button`.
+
 _This tutorial is a work in progress. More steps will be added as the project progresses._


### PR DESCRIPTION
- Added Heart (❤) button to the top-left map controls, to the right of the existing Info button
- Clicking it opens the left panel in a new "Support this App" view with hosting-costs blurb, PayPal/CashApp/Venmo donate links, and a contact link
- "← Back to Info" and "❤️ Support this App" nav links let users switch views in-place without reopening the panel
- Added shared `PanelCredit` component (author name + tagline) rendered at the top of both panel views
- Added GitHub repo link to The Data section of the info panel
- Fixed top map button dark-mode styling: solid `dark:bg-zinc-900 dark:border-zinc-700` instead of default semi-transparent border

Closes #140 