### PR TITLE
Add Accessible Color Scale

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -347,12 +347,14 @@ type Query {
 
 Crash points use a **severity-based color and opacity gradient** on the Mapbox circle layer. Bicyclist and pedestrian icons use slightly different hues but follow the same gradient system.
 
-| Severity Bucket  | Raw DB Values                                          | Color                         | Opacity | Size (base) | Default Visibility   |
-| ---------------- | ------------------------------------------------------ | ----------------------------- | ------- | ----------- | -------------------- |
-| **Death**        | "Dead at Scene", "Died in Hospital", "Dead on Arrival" | Dark Red (`#B71C1C`)          | ~85%    | 8px         | ✅ Shown             |
-| **Major Injury** | "Suspected Serious Injury"                             | Orange (`#E65100`)            | ~70%    | 7px         | ✅ Shown             |
-| **Minor Injury** | "Suspected Minor Injury", "Possible Injury"            | Yellow (`#F9A825`)            | ~55%    | 6px         | ✅ Shown             |
-| **None**         | "No Apparent Injury", "Unknown"                        | Pale Yellow-Green (`#C5E1A5`) | ~50%    | 5px         | ❌ Hidden by default |
+| Severity Bucket  | Raw DB Values                                          | Standard Color                | Accessible Color (Paul Tol Muted) | Opacity | Size (base) | Default Visibility   |
+| ---------------- | ------------------------------------------------------ | ----------------------------- | --------------------------------- | ------- | ----------- | -------------------- |
+| **Death**        | "Dead at Scene", "Died in Hospital", "Dead on Arrival" | Dark Red (`#B71C1C`)          | Indigo (`#332288`)                | ~85%    | 8px         | ✅ Shown             |
+| **Major Injury** | "Suspected Serious Injury"                             | Orange (`#F57C00`)            | Rose (`#CC6677`)                  | ~70%    | 7px         | ✅ Shown             |
+| **Minor Injury** | "Suspected Minor Injury", "Possible Injury"            | Yellow (`#FDD835`)            | Tan (`#DDCC77`)                   | ~55%    | 6px         | ✅ Shown             |
+| **None**         | "No Apparent Injury", "Unknown"                        | Pale Yellow-Green (`#C5E1A5`) | Teal (`#44AA99`)                  | ~50%    | 5px         | ❌ Hidden by default |
+
+The accessible palette is toggled via an Eye button in the top-right controls bar (also a Switch in Map Controls in the filter panel). The Paul Tol Muted scheme is distinguishable under all forms of color vision deficiency (protanopia, deuteranopia, tritanopia). Colors are centralized in `lib/crashColors.ts` and consumed by `CrashLayer.tsx`, `SeverityFilter.tsx`, and `InfoPanelContent.tsx`.
 
 **Mapbox implementation** using data-driven styling:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # CrashMap
 
-**Version:** 0.6.0
+**Version:** 0.6.1
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
 This project was bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Changelog
+
+### 2026-02-23 — Accessible Color Scale
+
+- Added colorblind-safe color palette toggle using the Paul Tol Muted scheme: teal / tan / rose / indigo replaces the standard red / orange / yellow / green
+- Eye icon button in the top-right controls bar enables/disables accessible colors; button fills when active to show state at a glance
+- "Accessible colors" Switch toggle also added to Map Controls in the filter panel
+- Severity legend dots in the filter panel and Map Key in the info panel update in sync with the map layers
+- Extracted shared `lib/crashColors.ts` constants used by all three locations; fixes pre-existing color inconsistency between `CrashLayer.tsx` and `SeverityFilter.tsx`
 
 ### 2026-02-23 — Support Panel
 

--- a/components/filters/GeographicFilter.tsx
+++ b/components/filters/GeographicFilter.tsx
@@ -61,6 +61,10 @@ export function GeographicFilter() {
     dispatch({ type: 'SET_SATELLITE', payload: checked })
   }
 
+  function handleAccessibleColorsToggle(checked: boolean) {
+    dispatch({ type: 'SET_ACCESSIBLE_COLORS', payload: checked })
+  }
+
   if (countiesLoading && citiesLoading && !countiesData && !citiesData) {
     return (
       <div className="space-y-4">
@@ -147,6 +151,16 @@ export function GeographicFilter() {
           />
           <Label htmlFor="satellite-view" className="text-sm cursor-pointer">
             Satellite view
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch
+            id="accessible-colors"
+            checked={filterState.accessibleColors}
+            onCheckedChange={handleAccessibleColorsToggle}
+          />
+          <Label htmlFor="accessible-colors" className="text-sm cursor-pointer">
+            Accessible colors
           </Label>
         </div>
       </div>

--- a/components/filters/SeverityFilter.tsx
+++ b/components/filters/SeverityFilter.tsx
@@ -2,19 +2,13 @@
 
 import { Checkbox } from '@/components/ui/checkbox'
 import { useFilterContext, type SeverityBucket } from '@/context/FilterContext'
-
-// Colors match the circle layer styling in CrashLayer.tsx.
-const SEVERITY_COLORS: Record<SeverityBucket | 'None', string> = {
-  Death: '#B71C1C',
-  'Major Injury': '#E65100',
-  'Minor Injury': '#F9A825',
-  None: '#C5E1A5',
-}
+import { STANDARD_COLORS, ACCESSIBLE_COLORS } from '@/lib/crashColors'
 
 const BUCKETS: SeverityBucket[] = ['Death', 'Major Injury', 'Minor Injury']
 
 export function SeverityFilter() {
   const { filterState, dispatch } = useFilterContext()
+  const colors = filterState.accessibleColors ? ACCESSIBLE_COLORS : STANDARD_COLORS
 
   function toggleBucket(bucket: SeverityBucket, checked: boolean) {
     const next = checked
@@ -37,7 +31,7 @@ export function SeverityFilter() {
             />
             <span
               className="size-2.5 shrink-0 rounded-full"
-              style={{ backgroundColor: SEVERITY_COLORS[bucket] }}
+              style={{ backgroundColor: colors[bucket] }}
               aria-hidden="true"
             />
             <label htmlFor={`severity-${bucket}`} className="cursor-pointer text-sm leading-none">
@@ -56,7 +50,7 @@ export function SeverityFilter() {
           />
           <span
             className="size-2.5 shrink-0 rounded-full"
-            style={{ backgroundColor: SEVERITY_COLORS['None'] }}
+            style={{ backgroundColor: colors['None'] }}
             aria-hidden="true"
           />
           <label htmlFor="severity-none" className="cursor-pointer text-sm leading-none">

--- a/components/info/InfoPanelContent.tsx
+++ b/components/info/InfoPanelContent.tsx
@@ -1,5 +1,9 @@
+'use client'
+
 import { ExternalLink } from 'lucide-react'
 import { PanelCredit } from './PanelCredit'
+import { useFilterContext } from '@/context/FilterContext'
+import { STANDARD_COLORS, ACCESSIBLE_COLORS } from '@/lib/crashColors'
 
 const resources = [
   {
@@ -29,6 +33,9 @@ interface InfoPanelContentProps {
 }
 
 export function InfoPanelContent({ onSwitchView }: InfoPanelContentProps) {
+  const { filterState } = useFilterContext()
+  const colors = filterState.accessibleColors ? ACCESSIBLE_COLORS : STANDARD_COLORS
+
   return (
     <div className="space-y-6">
       <PanelCredit />
@@ -45,6 +52,9 @@ export function InfoPanelContent({ onSwitchView }: InfoPanelContentProps) {
 
       <section>
         <h3 className="text-sm font-semibold mb-2">The Data</h3>
+        <p className="text-xs text-muted-foreground/60 mt-0.5">
+          *Current data only includes 2025 data from King County, more coming soon*
+        </p>
         <p className="text-sm text-muted-foreground leading-relaxed">
           Each record represents a reported crash involving at least one &quot;pedacyclist&quot; or
           pedestrian with a known location. Crashes are classified by the most severe injury to any
@@ -90,10 +100,10 @@ export function InfoPanelContent({ onSwitchView }: InfoPanelContentProps) {
         <h3 className="text-sm font-semibold mb-3">Map Key</h3>
         <ul className="space-y-2">
           {[
-            { color: '#B71C1C', opacity: 0.85, size: 14, label: 'Fatal' },
-            { color: '#E65100', opacity: 0.7, size: 12, label: 'Major Injury' },
-            { color: '#F9A825', opacity: 0.55, size: 11, label: 'Minor Injury' },
-            { color: '#C5E1A5', opacity: 0.5, size: 10, label: 'No Injury / Unknown' },
+            { color: colors['Death'], opacity: 0.85, size: 14, label: 'Fatal' },
+            { color: colors['Major Injury'], opacity: 0.7, size: 12, label: 'Major Injury' },
+            { color: colors['Minor Injury'], opacity: 0.55, size: 11, label: 'Minor Injury' },
+            { color: colors['None'], opacity: 0.5, size: 10, label: 'No Injury / Unknown' },
           ].map(({ color, opacity, size, label }) => (
             <li key={label} className="flex items-center gap-2.5">
               <span
@@ -135,7 +145,7 @@ export function InfoPanelContent({ onSwitchView }: InfoPanelContentProps) {
       </section>
       <section>
         <p className="text-xs text-muted-foreground/60 mt-0.5">
-          Version 0.6.0 &middot; Updated 2/23/2026
+          Version 0.6.1 &middot; Updated 2/23/2026
         </p>
         <p className="text-xs text-muted-foreground/60 mt-0.5">© Copyright 2026 Nick Magruder</p>
       </section>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRef, useEffect, useState } from 'react'
-import { Heart, Info, Loader2, SlidersHorizontal } from 'lucide-react'
+import { Eye, Heart, Info, Loader2, SlidersHorizontal } from 'lucide-react'
 import type { MapRef } from 'react-map-gl/mapbox'
 import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
@@ -35,7 +35,7 @@ export function AppShell() {
   const [infoOverlayOpen, setInfoOverlayOpen] = useState(false)
   const [infoPanelView, setInfoPanelView] = useState<InfoPanelView>('info')
   const mapRef = useRef<MapRef>(null)
-  const { filterState } = useFilterContext()
+  const { filterState, dispatch } = useFilterContext()
 
   // Call resize() after any panel transition so Mapbox recomputes canvas size.
   // 300ms matches the shadcn Sheet slide animation duration.
@@ -123,6 +123,29 @@ export function AppShell() {
 
         {/* Top-right controls */}
         <div className="absolute top-4 right-4 z-10 flex gap-2">
+          <Button
+            variant={filterState.accessibleColors ? 'default' : 'outline'}
+            size="icon"
+            className={filterState.accessibleColors ? '' : 'dark:bg-zinc-900 dark:border-zinc-700'}
+            onClick={() =>
+              dispatch({
+                type: 'SET_ACCESSIBLE_COLORS',
+                payload: !filterState.accessibleColors,
+              })
+            }
+            aria-label={
+              filterState.accessibleColors
+                ? 'Disable accessible colors'
+                : 'Enable accessible colors'
+            }
+            title={
+              filterState.accessibleColors
+                ? 'Disable accessible colors'
+                : 'Enable accessible colors'
+            }
+          >
+            <Eye className="size-4" />
+          </Button>
           <ThemeToggle className="dark:bg-zinc-900 dark:border-zinc-700" />
           {/* Sidebar toggle — desktop only */}
           <div className="hidden md:block">

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -7,6 +7,7 @@ import type { LayerProps } from 'react-map-gl/mapbox'
 import type { FeatureCollection, Point } from 'geojson'
 import { GET_CRASHES } from '@/lib/graphql/queries'
 import { useFilterContext, toCrashFilter, type CrashFilterInput } from '@/context/FilterContext'
+import { STANDARD_COLORS, ACCESSIBLE_COLORS } from '@/lib/crashColors'
 
 type CrashItem = {
   colliRptNum: string
@@ -39,6 +40,8 @@ export function CrashLayer() {
   // Reduce dot opacity by 10% on satellite to maintain visibility against imagery.
   const opacityOffset = filterState.satellite ? 0.15 : 0
 
+  const colors = filterState.accessibleColors ? ACCESSIBLE_COLORS : STANDARD_COLORS
+
   // Layers are rendered bottom-to-top: None → Minor → Major → Death
   // so higher-severity dots always appear on top of lower-severity ones.
   const noneLayer: LayerProps = {
@@ -46,7 +49,7 @@ export function CrashLayer() {
     type: 'circle',
     filter: ['==', ['get', 'severity'], 'None'],
     paint: {
-      'circle-color': '#C5E1A5',
+      'circle-color': colors['None'],
       'circle-opacity': 0.5 + opacityOffset,
       'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 1, 10, 5, 15, 9],
       'circle-stroke-width': 0,
@@ -58,7 +61,7 @@ export function CrashLayer() {
     type: 'circle',
     filter: ['==', ['get', 'severity'], 'Minor Injury'],
     paint: {
-      'circle-color': '#FDD835',
+      'circle-color': colors['Minor Injury'],
       'circle-opacity': 0.55 + opacityOffset,
       'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 1.5, 10, 6, 15, 12],
       'circle-stroke-width': 0,
@@ -70,7 +73,7 @@ export function CrashLayer() {
     type: 'circle',
     filter: ['==', ['get', 'severity'], 'Major Injury'],
     paint: {
-      'circle-color': '#F57C00',
+      'circle-color': colors['Major Injury'],
       'circle-opacity': 0.7 + opacityOffset,
       'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 2, 10, 7, 15, 15],
       'circle-stroke-width': 0,
@@ -82,7 +85,7 @@ export function CrashLayer() {
     type: 'circle',
     filter: ['==', ['get', 'severity'], 'Death'],
     paint: {
-      'circle-color': '#B71C1C',
+      'circle-color': colors['Death'],
       'circle-opacity': 0.85 + opacityOffset,
       'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 2.5, 10, 8, 15, 18],
       'circle-stroke-width': 0,

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -22,6 +22,7 @@ export interface FilterState {
   city: string | null
   updateWithMovement: boolean // when true, query uses viewport bbox instead of geo text filters
   satellite: boolean // when true, map uses satellite-streets style regardless of theme
+  accessibleColors: boolean // when true, uses colorblind-safe Paul Tol Muted palette
   totalCount: number | null // populated by CrashLayer after query
   isLoading: boolean // true while a filter-triggered refetch is in flight
 }
@@ -50,6 +51,7 @@ export type FilterAction =
   | { type: 'SET_CITY'; payload: string | null }
   | { type: 'SET_UPDATE_WITH_MOVEMENT'; payload: boolean }
   | { type: 'SET_SATELLITE'; payload: boolean }
+  | { type: 'SET_ACCESSIBLE_COLORS'; payload: boolean }
   | { type: 'SET_TOTAL_COUNT'; payload: number | null }
   | { type: 'SET_LOADING'; payload: boolean }
   | { type: 'RESET' }
@@ -83,6 +85,7 @@ const initialState: FilterState = {
   city: null,
   updateWithMovement: false,
   satellite: false,
+  accessibleColors: false,
   totalCount: null,
   isLoading: false,
 }
@@ -122,6 +125,8 @@ function filterReducer(filterState: FilterState, action: FilterAction): FilterSt
       return { ...filterState, updateWithMovement: action.payload }
     case 'SET_SATELLITE':
       return { ...filterState, satellite: action.payload }
+    case 'SET_ACCESSIBLE_COLORS':
+      return { ...filterState, accessibleColors: action.payload }
     case 'SET_TOTAL_COUNT':
       return { ...filterState, totalCount: action.payload }
     case 'SET_LOADING':

--- a/lib/crashColors.ts
+++ b/lib/crashColors.ts
@@ -1,0 +1,26 @@
+import type { SeverityBucket } from '@/context/FilterContext'
+
+type ColorMap = Record<SeverityBucket, string>
+
+/**
+ * Standard severity color palette.
+ * Rendered bottom-to-top: None → Minor → Major → Death.
+ */
+export const STANDARD_COLORS: ColorMap = {
+  None: '#C5E1A5',
+  'Minor Injury': '#FDD835',
+  'Major Injury': '#F57C00',
+  Death: '#B71C1C',
+}
+
+/**
+ * Accessible severity color palette — Paul Tol Muted scheme.
+ * Distinguishable under all forms of color vision deficiency
+ * (protanopia, deuteranopia, tritanopia).
+ */
+export const ACCESSIBLE_COLORS: ColorMap = {
+  None: '#44AA99',
+  'Minor Injury': '#DDCC77',
+  'Major Injury': '#CC6677',
+  Death: '#332288',
+}


### PR DESCRIPTION
- Added colorblind-safe color palette toggle using the Paul Tol Muted scheme: teal / tan / rose / indigo replaces the standard red / orange / yellow / green
- Eye icon button in the top-right controls bar enables/disables accessible colors; button fills when active to show state at a glance
- "Accessible colors" Switch toggle also added to Map Controls in the filter panel
- Severity legend dots in the filter panel and Map Key in the info panel update in sync with the map layers
- Extracted shared `lib/crashColors.ts` constants used by all three locations; fixes pre-existing color inconsistency between `CrashLayer.tsx` and `SeverityFilter.tsx`

Closes #142 