### PR TITLE
Drop CrashStatePlaneX / CrashStatePlaneY from Prisma Schema

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,8 +150,6 @@ CREATE TABLE public.crashdata
     "MostSevereInjuryType" text,           -- Injury severity (e.g., fatal, serious, minor)
     "AgeGroup" text,                       -- Age group of involved person
     "InvolvedPersons" smallint,            -- Number of persons involved
-    "CrashStatePlaneX" real,               -- State plane X coordinate
-    "CrashStatePlaneY" real,               -- State plane Y coordinate
     "Latitude" double precision,           -- GPS latitude (used for Mapbox)
     "Longitude" double precision,          -- GPS longitude (used for Mapbox)
     "Mode" text,                           -- "Bicyclist" or "Pedestrian"
@@ -205,8 +203,6 @@ model CrashData {
   mostSevereInjury    String?  @map("MostSevereInjuryType")
   ageGroup            String?  @map("AgeGroup")
   involvedPersons     Int?     @map("InvolvedPersons") @db.SmallInt
-  crashStatePlaneX    Float?   @map("CrashStatePlaneX") @db.Real
-  crashStatePlaneY    Float?   @map("CrashStatePlaneY") @db.Real
   latitude            Float?   @map("Latitude")
   longitude           Float?   @map("Longitude")
   mode                String?  @map("Mode")

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # CrashMap
 
-**Version:** 0.6.1
+**Version:** 0.7.0
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
 This project was bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Changelog
+
+### 2026-02-24 — Drop CrashStatePlaneX / CrashStatePlaneY from Prisma Schema
+
+- Removed `crashStatePlaneX` and `crashStatePlaneY` fields from `prisma/schema.prisma` to match the DB columns already dropped from the Render PostgreSQL database; all spatial work uses `Latitude`, `Longitude`, and the PostGIS `geom` generated column exclusively
+- Regenerated Prisma client (`npx prisma generate`); no migration needed since the DB columns were already dropped manually
 
 ### 2026-02-23 — Accessible Color Scale
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,8 +19,6 @@ model CrashData {
   mostSevereInjuryType String?                  @map("MostSevereInjuryType")
   ageGroup             String?                  @map("AgeGroup")
   involvedPersons      Int?                     @map("InvolvedPersons") @db.SmallInt
-  crashStatePlaneX     Float?                   @map("CrashStatePlaneX") @db.Real
-  crashStatePlaneY     Float?                   @map("CrashStatePlaneY") @db.Real
   latitude             Float?                   @map("Latitude")
   longitude            Float?                   @map("Longitude")
   mode                 String?                  @map("Mode")

--- a/tutorial.md
+++ b/tutorial.md
@@ -50,8 +50,6 @@ CREATE TABLE public.crashdata
     "MostSevereInjuryType" text,          -- Death, Serious Injury, Minor Injury, None/Unknown
     "AgeGroup" text,
     "InvolvedPersons" smallint,
-    "CrashStatePlaneX" real,
-    "CrashStatePlaneY" real,
     "Latitude" double precision,
     "Longitude" double precision,
     "Mode" text,                          -- "Bicyclist" or "Pedestrian"
@@ -219,8 +217,6 @@ model CrashData {
   mostSevereInjuryType String?   @map("MostSevereInjuryType")
   ageGroup             String?   @map("AgeGroup")
   involvedPersons      Int?      @map("InvolvedPersons") @db.SmallInt
-  crashStatePlaneX     Float?    @map("CrashStatePlaneX") @db.Real
-  crashStatePlaneY     Float?    @map("CrashStatePlaneY") @db.Real
   latitude             Float?    @map("Latitude")
   longitude            Float?    @map("Longitude")
   mode                 String?   @map("Mode")


### PR DESCRIPTION
- Removed `crashStatePlaneX` and `crashStatePlaneY` fields from `prisma/schema.prisma` to match the DB columns already dropped from the Render PostgreSQL database; all spatial work uses `Latitude`, `Longitude`, and the PostGIS `geom` generated column exclusively
- Regenerated Prisma client (`npx prisma generate`); no migration needed since the DB columns were already dropped manually

Closes #144 