### PR TITLE
Date Filter Overhaul, Data Bounds Validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -331,6 +331,8 @@ type FilterOptions {
   years: [String!]!
   severities: [String!]!
   modes: [String!]!
+  minDate: String # earliest CrashDate in DB (YYYY-MM-DD); used for date range validation
+  maxDate: String # latest CrashDate in DB (YYYY-MM-DD); used for date range validation
 }
 
 type Query {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ApolloProvider } from './apollo-provider'
 import { ThemeProvider } from '@/components/theme-provider'
 import { FilterProvider } from '@/context/FilterContext'
 import { FilterUrlSync } from '@/components/FilterUrlSync'
+import { Toaster } from '@/components/ui/sonner'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './globals.css'
 
@@ -46,6 +47,7 @@ export default function RootLayout({
                 <FilterUrlSync />
               </Suspense>
               {children}
+              <Toaster />
             </FilterProvider>
           </ApolloProvider>
         </ThemeProvider>

--- a/components/info/InfoPanelContent.tsx
+++ b/components/info/InfoPanelContent.tsx
@@ -52,9 +52,8 @@ export function InfoPanelContent({ onSwitchView }: InfoPanelContentProps) {
 
       <section>
         <h3 className="text-sm font-semibold mb-2">The Data</h3>
-        <p className="text-xs text-muted-foreground/60 mt-0.5">
-          *Current data only includes 2025 data from King County, more coming soon*
-        </p>
+        <p className="text-sm text-muted-foreground leading-relaxed">The current data range is:</p>
+        <p className="text-sm text-muted-foreground leading-relaxed">2015 - Jan 2026</p>
         <p className="text-sm text-muted-foreground leading-relaxed">
           Each record represents a reported crash involving at least one &quot;pedacyclist&quot; or
           pedestrian with a known location. Crashes are classified by the most severe injury to any

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRef, useEffect, useState } from 'react'
-import { Eye, Heart, Info, Loader2, SlidersHorizontal } from 'lucide-react'
+import { Eye, Heart, Info, Loader2, SlidersHorizontal, TriangleAlert } from 'lucide-react'
 import type { MapRef } from 'react-map-gl/mapbox'
 import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
@@ -62,6 +62,16 @@ export function AppShell() {
         <ErrorBoundary fallback={mapFallback}>
           <MapContainer ref={mapRef} />
         </ErrorBoundary>
+
+        {/* Top-center: no-date warning banner */}
+        {filterState.dateFilter.type === 'none' && (
+          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 pointer-events-none">
+            <div className="rounded-full bg-background/90 border px-4 py-1.5 text-sm font-medium shadow-sm dark:bg-zinc-900/90 dark:border-zinc-700 flex items-center gap-2 text-warning-foreground">
+              <TriangleAlert className="size-4 text-yellow-600 dark:text-yellow-400" />
+              No dates selected — use the filters to select a date range
+            </div>
+          </div>
+        )}
 
         {/* Top-left: info/about toggle + support */}
         <div className="absolute top-4 left-4 z-10 flex gap-2">

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -117,15 +117,19 @@ export function CrashLayer() {
       }
     : toCrashFilter(filterState)
 
+  const noDateFilter = filterState.dateFilter.type === 'none'
+
   const { data, previousData, error, loading } = useQuery<GetCrashesQuery>(GET_CRASHES, {
     variables: { filter: queryFilter, limit: 5000 },
     notifyOnNetworkStatusChange: true,
+    skip: noDateFilter,
   })
 
   // During a loading refetch, data is undefined (cache miss on new bbox/variables).
   // Fall back to previousData so the dots from the last result stay visible until
   // the new response arrives — prevents the flash-to-empty on every map move.
-  const displayData = data ?? previousData
+  // When no date filter is active, force undefined so the map clears immediately.
+  const displayData = noDateFilter ? undefined : (data ?? previousData)
 
   // Surface loading state so SummaryBar can show a refetch indicator.
   useEffect(() => {

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+          '--border-radius': 'var(--radius)',
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -25,6 +25,7 @@ export interface FilterState {
   accessibleColors: boolean // when true, uses colorblind-safe Paul Tol Muted palette
   totalCount: number | null // populated by CrashLayer after query
   isLoading: boolean // true while a filter-triggered refetch is in flight
+  dataBounds: { minDate: string; maxDate: string } | null // min/max CrashDate in DB
 }
 
 // The URL-serializable subset of FilterState (no derived fields).
@@ -54,6 +55,7 @@ export type FilterAction =
   | { type: 'SET_ACCESSIBLE_COLORS'; payload: boolean }
   | { type: 'SET_TOTAL_COUNT'; payload: number | null }
   | { type: 'SET_LOADING'; payload: boolean }
+  | { type: 'SET_DATE_BOUNDS'; payload: { minDate: string; maxDate: string } }
   | { type: 'RESET' }
   | { type: 'INIT_FROM_URL'; payload: UrlFilterState }
 
@@ -88,6 +90,7 @@ const initialState: FilterState = {
   accessibleColors: false,
   totalCount: null,
   isLoading: false,
+  dataBounds: null,
 }
 
 // ── Reducer ───────────────────────────────────────────────────────────────────
@@ -131,6 +134,8 @@ function filterReducer(filterState: FilterState, action: FilterAction): FilterSt
       return { ...filterState, totalCount: action.payload }
     case 'SET_LOADING':
       return { ...filterState, isLoading: action.payload }
+    case 'SET_DATE_BOUNDS':
+      return { ...filterState, dataBounds: action.payload }
     case 'RESET':
       return initialState
     case 'INIT_FROM_URL':

--- a/lib/graphql/__generated__/types.ts
+++ b/lib/graphql/__generated__/types.ts
@@ -88,6 +88,8 @@ export type FilterOptions = {
   __typename?: 'FilterOptions'
   cities: Array<Scalars['String']['output']>
   counties: Array<Scalars['String']['output']>
+  maxDate?: Maybe<Scalars['String']['output']>
+  minDate?: Maybe<Scalars['String']['output']>
   modes: Array<Scalars['String']['output']>
   severities: Array<Scalars['String']['output']>
   states: Array<Scalars['String']['output']>
@@ -337,6 +339,8 @@ export type FilterOptionsResolvers<
     ContextType,
     Partial<FilterOptionsCountiesArgs>
   >
+  maxDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  minDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   modes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>
   severities?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>
   states?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -6,6 +6,8 @@ export type GetFilterOptionsQuery = {
   filterOptions: {
     states: string[]
     years: number[]
+    minDate: string | null
+    maxDate: string | null
   }
 }
 
@@ -28,6 +30,8 @@ export const GET_FILTER_OPTIONS = gql`
     filterOptions {
       states
       years
+      minDate
+      maxDate
     }
   }
 `

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -221,5 +221,19 @@ export const resolvers: Resolvers = {
     severities: () => ['Death', 'Major Injury', 'Minor Injury', 'None'],
 
     modes: () => ['Bicyclist', 'Pedestrian'],
+
+    minDate: async () => {
+      const result = await prisma.$queryRaw<[{ min: Date | null }]>`
+        SELECT MIN("CrashDate") as min FROM crashdata
+      `
+      return result[0]?.min?.toISOString().slice(0, 10) ?? null
+    },
+
+    maxDate: async () => {
+      const result = await prisma.$queryRaw<[{ max: Date | null }]>`
+        SELECT MAX("CrashDate") as max FROM crashdata
+      `
+      return result[0]?.max?.toISOString().slice(0, 10) ?? null
+    },
   },
 }

--- a/lib/graphql/typeDefs.ts
+++ b/lib/graphql/typeDefs.ts
@@ -81,6 +81,8 @@ export const typeDefs = `#graphql
     years: [Int!]!
     severities: [String!]!
     modes: [String!]!
+    minDate: String   # earliest CrashDate in DB as YYYY-MM-DD
+    maxDate: String   # latest CrashDate in DB as YYYY-MM-DD
   }
 
   # ── Queries ───────────────────────────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-day-picker": "^9.13.2",
         "react-dom": "19.2.3",
         "react-map-gl": "^8.1.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.1"
       },
       "devDependencies": {
@@ -18432,6 +18433,16 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/sort-asc": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-day-picker": "^9.13.2",
     "react-dom": "19.2.3",
     "react-map-gl": "^8.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- Replaced custom date picker (text inputs, year-nav arrows, Apply button) with the default shadcn Range Calendar (`mode="range"`, `captionLayout="dropdown"`) — reduced `DateFilter.tsx` from 247 to ~155 lines
- Added month/year dropdown navigation bounded by `dataBounds` (`startMonth`/`endMonth` props)
- Fixed DayPicker v9 single-click bug: v9 sets `from === to` on first click; intercepted in `handleRangeSelect` to treat it as start-only, keeping the popover open for end-date selection
- Added controlled `month`/`setMonth` state + `onMonthChange` handler to prevent dropdown navigation from corrupting the pending range selection
- Changed Clear to keep the popover open (allows immediately starting a new selection)
- `dateFilter.type === 'none'` now skips the GraphQL query entirely (`skip: noDateFilter` in `CrashLayer`), clearing all map dots when no date is active
- Added persistent "No dates selected" warning banner (top-center of map, `TriangleAlert` icon) that appears whenever `dateFilter.type === 'none'`

- Refactored `DateFilter.tsx` to follow a new project-wide React file structure convention (imports → types → helpers → component → hooks → guard clauses → render); all React files follow this order going forward
- Fixed calendar jumping to today's month after first date click by adding controlled `month`/`onMonthChange` state
- Added prev/next year arrow buttons (`«`/`»`) inside the popover, sitting above the calendar's own month arrows; both share the same controlled month state
- Added Start/End text inputs (MM/DD/YYYY format) inside the popover above the calendar; bidirectional sync: calendar clicks fill the inputs, valid typed dates update the calendar highlight and navigate to that month
- Changed commit behavior: dates are no longer applied on calendar click; they commit only on "Apply" button click or when clicking outside the popover; an "Apply" button appears when a complete pending range exists; "Clear" appears when a committed range exists; both share the same footer row
- Added `dataBounds: { minDate: string; maxDate: string } | null` to `FilterState` in `FilterContext`; populated on app load via `GET_FILTER_OPTIONS` query dispatching `SET_DATE_BOUNDS`
- Added `minDate` and `maxDate` fields to the `FilterOptions` GraphQL type and resolvers (each runs `SELECT MIN/MAX("CrashDate") FROM crashdata`); updated `GET_FILTER_OPTIONS` client query and generated types
- Installed shadcn Sonner (`npx shadcn@latest add sonner`); added `<Toaster />` to `app/layout.tsx`
- Added validation in `DateFilter` that fires a toast error (via Sonner) when: start > end, start < `dataBounds.minDate`, end > `dataBounds.maxDate`, or text input is 10 chars but not a valid MM/DD/YYYY date; validation blocks commit on Apply but allows close on outside-click (discards pending range)
- Added shadcn `Input` component (`npx shadcn@latest add input`)

Closes #146 