### PR TITLE
Fix map controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ This project was bootstrapped with [`create-next-app`](https://nextjs.org/docs/a
 
 ## Changelog
 
+### 2026-02-25 — Map Controls: Popup Centering, Metered Zoom, Tilt & Zoom Buttons
+
+- Popup centering: `flyTo` now uses Mapbox `padding` (mobile: top 200px / bottom 70px, desktop: top 150px) so the popup clears the top UI buttons; padding resets to zero when the popup is dismissed
+- Metered zoom: clicking a crash flies to exactly halfway between the current zoom and 15.5 (e.g. at zoom 10 → lands at zoom 12.75) rather than always jumping to 15.5
+- Viewport retention: panning or zooming while a popup is open now updates the saved viewport via `handleMoveEnd`, so dismissing the popup returns to wherever the user navigated; `flyingRef` guards programmatic `flyTo` animations from triggering false saves
+- Added tilt-toggle button (Box icon) at bottom-left of the map: toggles between flat view (pitch 0°) and 3D view (pitch 45°) via `map.easeTo()`; button fills (`variant="default"`) when tilted
+- Added zoom in / zoom out buttons (Plus / Minus icons) at bottom-left above the SummaryBar
+
 ### 2026-02-25 — Date Filter: Named Preset Buttons
 
 - Replaced hardcoded year quick-select buttons (2025–2022) with four dynamic presets: **YTD**, **90 Days**, **Last Year**, and **3 Years**

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,7 +1,17 @@
 'use client'
 
 import { useRef, useEffect, useState } from 'react'
-import { Eye, Heart, Info, Loader2, SlidersHorizontal, TriangleAlert } from 'lucide-react'
+import {
+  Box,
+  Eye,
+  Heart,
+  Info,
+  Loader2,
+  Minus,
+  Plus,
+  SlidersHorizontal,
+  TriangleAlert,
+} from 'lucide-react'
 import type { MapRef } from 'react-map-gl/mapbox'
 import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
@@ -34,6 +44,7 @@ export function AppShell() {
   const [infoPanelPinned, setInfoPanelPinned] = useState(true)
   const [infoOverlayOpen, setInfoOverlayOpen] = useState(false)
   const [infoPanelView, setInfoPanelView] = useState<InfoPanelView>('info')
+  const [tilted, setTilted] = useState(false)
   const mapRef = useRef<MapRef>(null)
   const { filterState, dispatch } = useFilterContext()
 
@@ -189,6 +200,44 @@ export function AppShell() {
               )}
             </Button>
           </div>
+        </div>
+
+        {/* Bottom-left: tilt + zoom controls */}
+        <div className="absolute bottom-14 left-4 z-10 flex flex-col gap-2 md:bottom-6">
+          <Button
+            variant={tilted ? 'default' : 'outline'}
+            size="icon"
+            className={tilted ? '' : 'dark:bg-zinc-900 dark:border-zinc-700'}
+            onClick={() => {
+              const map = mapRef.current?.getMap()
+              if (!map) return
+              const isTilted = map.getPitch() > 0
+              map.easeTo({ pitch: isTilted ? 0 : 45, duration: 1000 })
+              setTilted(!isTilted)
+            }}
+            aria-label={tilted ? 'Reset to flat view' : 'Tilt map to 3D view'}
+            title={tilted ? 'Reset to flat view' : 'Tilt map to 3D view'}
+          >
+            <Box className="size-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="dark:bg-zinc-900 dark:border-zinc-700"
+            onClick={() => mapRef.current?.getMap()?.zoomIn()}
+            aria-label="Zoom in"
+          >
+            <Plus className="size-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="dark:bg-zinc-900 dark:border-zinc-700"
+            onClick={() => mapRef.current?.getMap()?.zoomOut()}
+            aria-label="Zoom out"
+          >
+            <Minus className="size-4" />
+          </Button>
         </div>
 
         <SummaryBar


### PR DESCRIPTION
- Popup centering: `flyTo` now uses Mapbox `padding` (mobile: top 200px / bottom 70px, desktop: top 150px) so the popup clears the top UI buttons; padding resets to zero when the popup is dismissed
- Metered zoom: clicking a crash flies to exactly halfway between the current zoom and 15.5 (e.g. at zoom 10 → lands at zoom 12.75) rather than always jumping to 15.5
- Viewport retention: panning or zooming while a popup is open now updates the saved viewport via `handleMoveEnd`, so dismissing the popup returns to wherever the user navigated; `flyingRef` guards programmatic `flyTo` animations from triggering false saves
- Added tilt-toggle button (Box icon) at bottom-left of the map: toggles between flat view (pitch 0°) and 3D view (pitch 45°) via `map.easeTo()`; button fills (`variant="default"`) when tilted
- Added zoom in / zoom out buttons (Plus / Minus icons) at bottom-left above the SummaryBar

Closes #149 