### PR TITLE
Simplify Desktop Panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This project was bootstrapped with [`create-next-app`](https://nextjs.org/docs/a
 
 ## Changelog
 
+### 2026-02-25 — Simplify Desktop Panels: Pinned-Only Layout
+
+- Removed the "unpinned" (Sheet overlay) variant from both desktop side panels (`Sidebar`, `InfoSidePanel`); panels are now always flex-column siblings that push the map
+- Removed Pin/PinOff buttons and `sidebarPinned`/`infoPanelPinned` state from `AppShell`
+- Reduced `map.resize()` timeout from 300ms to 0ms — the delay was only needed for the Sheet slide animation, which no longer exists; eliminates the blank-bar flash after closing a panel
+
 ### 2026-02-25 — Map Controls: Popup Centering, Metered Zoom, Tilt & Zoom Buttons
 
 - Popup centering: `flyTo` now uses Mapbox `padding` (mobile: top 200px / bottom 70px, desktop: top 150px) so the popup clears the top UI buttons; padding resets to zero when the popup is dismissed

--- a/components/info/InfoSidePanel.tsx
+++ b/components/info/InfoSidePanel.tsx
@@ -1,18 +1,14 @@
 'use client'
 
-import { Pin, PinOff, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Sheet, SheetContent, SheetTitle, SheetClose } from '@/components/ui/sheet'
 import { InfoPanelContent } from './InfoPanelContent'
 import { SupportPanelContent } from './SupportPanelContent'
 
 export type InfoPanelView = 'info' | 'support'
 
 interface InfoSidePanelProps {
-  pinned: boolean
   onClose: () => void
-  onTogglePin: () => void
-  isOpen?: boolean
   view?: InfoPanelView
   onSwitchView?: (view: InfoPanelView) => void
 }
@@ -36,61 +32,18 @@ function PanelBody({
   )
 }
 
-export function InfoSidePanel({
-  pinned,
-  onClose,
-  onTogglePin,
-  isOpen,
-  view = 'info',
-  onSwitchView,
-}: InfoSidePanelProps) {
-  if (pinned) {
-    return (
-      <div className="hidden md:flex flex-col w-80 flex-shrink-0 border-r bg-background h-full overflow-hidden">
-        <div className="flex items-center gap-1 border-b px-4 py-3">
-          <h2 className="text-base font-semibold flex-1">{titles[view]}</h2>
-          <Button variant="ghost" size="icon" onClick={onTogglePin} aria-label="Unpin panel">
-            <PinOff className="size-4" />
-          </Button>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
-            <X className="size-4" />
-          </Button>
-        </div>
-        <div className="flex-1 overflow-y-auto px-4 py-4">
-          <PanelBody view={view} onSwitchView={onSwitchView} />
-        </div>
-      </div>
-    )
-  }
-
+export function InfoSidePanel({ onClose, view = 'info', onSwitchView }: InfoSidePanelProps) {
   return (
-    <Sheet open={isOpen ?? false} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent
-        side="left"
-        className="w-80 sm:max-w-80 flex flex-col gap-0"
-        showCloseButton={false}
-      >
-        <div className="flex items-center gap-1 border-b px-4 py-3">
-          <SheetTitle className="flex-1">{titles[view]}</SheetTitle>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onTogglePin}
-            aria-label="Pin panel"
-            className="hidden md:flex"
-          >
-            <Pin className="size-4" />
-          </Button>
-          <SheetClose asChild>
-            <Button variant="ghost" size="icon" aria-label="Close">
-              <X className="size-4" />
-            </Button>
-          </SheetClose>
-        </div>
-        <div className="flex-1 overflow-y-auto px-4 py-4">
-          <PanelBody view={view} onSwitchView={onSwitchView} />
-        </div>
-      </SheetContent>
-    </Sheet>
+    <div className="hidden md:flex flex-col w-80 flex-shrink-0 border-r bg-background h-full overflow-hidden">
+      <div className="flex items-center gap-1 border-b px-4 py-3">
+        <h2 className="text-base font-semibold flex-1">{titles[view]}</h2>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+          <X className="size-4" />
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <PanelBody view={view} onSwitchView={onSwitchView} />
+      </div>
+    </div>
   )
 }

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -38,10 +38,8 @@ const mapFallback = (
 
 export function AppShell() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
-  const [sidebarPinned, setSidebarPinned] = useState(true)
   const [overlayOpen, setOverlayOpen] = useState(false)
   const [infoPanelOpen, setInfoPanelOpen] = useState(true)
-  const [infoPanelPinned, setInfoPanelPinned] = useState(true)
   const [infoOverlayOpen, setInfoOverlayOpen] = useState(false)
   const [infoPanelView, setInfoPanelView] = useState<InfoPanelView>('info')
   const [tilted, setTilted] = useState(false)
@@ -49,20 +47,17 @@ export function AppShell() {
   const { filterState, dispatch } = useFilterContext()
 
   // Call resize() after any panel transition so Mapbox recomputes canvas size.
-  // 300ms matches the shadcn Sheet slide animation duration.
   useEffect(() => {
-    const id = setTimeout(() => mapRef.current?.resize(), 300)
+    const id = setTimeout(() => mapRef.current?.resize(), 0)
     return () => clearTimeout(id)
-  }, [sidebarOpen, overlayOpen, infoPanelOpen, infoOverlayOpen, sidebarPinned, infoPanelPinned])
+  }, [sidebarOpen, overlayOpen, infoPanelOpen, infoOverlayOpen])
 
   return (
     <div className="flex w-full h-full">
       {/* Left: info panel (desktop, pinned) */}
-      {infoPanelOpen && infoPanelPinned && (
+      {infoPanelOpen && (
         <InfoSidePanel
-          pinned
           onClose={() => setInfoPanelOpen(false)}
-          onTogglePin={() => setInfoPanelPinned(false)}
           view={infoPanelView}
           onSwitchView={setInfoPanelView}
         />
@@ -247,22 +242,6 @@ export function AppShell() {
         />
 
         <ErrorBoundary fallback={null}>
-          {/* Desktop non-pinned info panel (Sheet from left) */}
-          <InfoSidePanel
-            isOpen={infoPanelOpen && !infoPanelPinned}
-            onClose={() => setInfoPanelOpen(false)}
-            pinned={false}
-            onTogglePin={() => setInfoPanelPinned(true)}
-            view={infoPanelView}
-            onSwitchView={setInfoPanelView}
-          />
-          {/* Desktop non-pinned filter panel (Sheet from right) */}
-          <Sidebar
-            isOpen={sidebarOpen && !sidebarPinned}
-            onClose={() => setSidebarOpen(false)}
-            pinned={false}
-            onTogglePin={() => setSidebarPinned(true)}
-          />
           {/* Mobile overlays */}
           <FilterOverlay isOpen={overlayOpen} onClose={() => setOverlayOpen(false)} />
           <InfoOverlay
@@ -275,13 +254,7 @@ export function AppShell() {
       </div>
 
       {/* Right: filter panel (desktop, pinned) */}
-      {sidebarOpen && sidebarPinned && (
-        <Sidebar
-          pinned
-          onClose={() => setSidebarOpen(false)}
-          onTogglePin={() => setSidebarPinned(false)}
-        />
-      )}
+      {sidebarOpen && <Sidebar onClose={() => setSidebarOpen(false)} />}
     </div>
   )
 }

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { Pin, PinOff, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Sheet, SheetContent, SheetTitle, SheetClose } from '@/components/ui/sheet'
 import { ModeToggle } from '@/components/filters/ModeToggle'
 import { SeverityFilter } from '@/components/filters/SeverityFilter'
 import { DateFilter } from '@/components/filters/DateFilter'
@@ -11,10 +10,7 @@ import { ExportButton } from '@/components/export/ExportButton'
 import { useFilterContext } from '@/context/FilterContext'
 
 interface SidebarProps {
-  pinned: boolean
   onClose: () => void
-  onTogglePin: () => void
-  isOpen?: boolean
 }
 
 function FilterContent() {
@@ -35,54 +31,18 @@ function FilterContent() {
   )
 }
 
-export function Sidebar({ pinned, onClose, onTogglePin, isOpen }: SidebarProps) {
-  if (pinned) {
-    return (
-      <div className="hidden md:flex flex-col w-80 flex-shrink-0 border-l bg-background h-full overflow-hidden">
-        <div className="flex items-center gap-1 border-b px-4 py-3">
-          <h2 className="text-base font-semibold flex-1">Filters</h2>
-          <Button variant="ghost" size="icon" onClick={onTogglePin} aria-label="Unpin panel">
-            <PinOff className="size-4" />
-          </Button>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close filters">
-            <X className="size-4" />
-          </Button>
-        </div>
-        <div className="flex-1 overflow-y-auto">
-          <FilterContent />
-        </div>
-      </div>
-    )
-  }
-
+export function Sidebar({ onClose }: SidebarProps) {
   return (
-    <Sheet open={isOpen ?? false} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent
-        side="right"
-        className="w-80 sm:max-w-80 flex flex-col gap-0"
-        showCloseButton={false}
-      >
-        <div className="flex items-center gap-1 border-b px-4 py-3">
-          <SheetTitle className="flex-1">Filters</SheetTitle>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onTogglePin}
-            aria-label="Pin panel"
-            className="hidden md:flex"
-          >
-            <Pin className="size-4" />
-          </Button>
-          <SheetClose asChild>
-            <Button variant="ghost" size="icon" aria-label="Close filters">
-              <X className="size-4" />
-            </Button>
-          </SheetClose>
-        </div>
-        <div className="flex-1 overflow-y-auto">
-          <FilterContent />
-        </div>
-      </SheetContent>
-    </Sheet>
+    <div className="hidden md:flex flex-col w-80 flex-shrink-0 border-l bg-background h-full overflow-hidden">
+      <div className="flex items-center gap-1 border-b px-4 py-3">
+        <h2 className="text-base font-semibold flex-1">Filters</h2>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close filters">
+          <X className="size-4" />
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <FilterContent />
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
- Removed the "unpinned" (Sheet overlay) variant from both desktop side panels (`Sidebar`, `InfoSidePanel`); panels are now always flex-column siblings that push the map
- Removed Pin/PinOff buttons and `sidebarPinned`/`infoPanelPinned` state from `AppShell`
- Reduced `map.resize()` timeout from 300ms to 0ms — the delay was only needed for the Sheet slide animation, which no longer exists; eliminates the blank-bar flash after closing a panel

Closes #152 