### PR TITLE
Add Display Limit & Toast Warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # CrashMap
 
-**Version:** 0.7.0
+**Version:** 0.7.1
 
 A public-facing web application for visualizing crash data involving injuries and fatalities to bicyclists and pedestrians. Built with Next.js, Apollo GraphQL, Prisma, PostgreSQL/PostGIS, and Mapbox GL JS. The data is self-collected from state DOT websites and stored in a single PostgreSQL table. CrashMap follows a **classic three-tier architecture** (Client → Server → Data) deployed as a single Next.js application on Render.
 
 This project was bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Changelog
+
+### 2026-02-25 — Display Limit & Toast Warning
+
+- Raised the crash display cap from 5,000 to 10,000 (resolver hard cap, `CrashLayer` query variable, and CSV export limit all updated)
+- Added a persistent warning toast when `totalCount > 10,000`: "Showing 10,000 of X,XXX crashes — narrow your filters to see all results." (auto-dismisses when filters are narrowed below the limit)
+- Repositioned toasts to top-center on desktop; on mobile (≤600px) Sonner's full-width mode is used with `mobileOffset={{ top: 80 }}` to push toasts below the top button row
 
 ### 2026-02-25 — Simplify Desktop Panels: Pinned-Only Layout
 

--- a/components/export/ExportButton.tsx
+++ b/components/export/ExportButton.tsx
@@ -42,7 +42,7 @@ export function ExportButton({ variant = 'icon' }: ExportButtonProps) {
 
   async function handleExport() {
     const { data } = await fetchCrashes({
-      variables: { filter: toCrashFilter(filterState), limit: 5000 },
+      variables: { filter: toCrashFilter(filterState), limit: 10000 },
     })
     if (!data) return
 

--- a/components/filters/ModeToggle.tsx
+++ b/components/filters/ModeToggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggle() {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1">
       <p className="text-sm font-medium">Mode</p>
       <ToggleGroup type="single" variant="outline" value={value} onValueChange={handleChange}>
         <ToggleGroupItem value="all" aria-label="All modes">

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,17 +1,7 @@
 'use client'
 
 import { useRef, useEffect, useState } from 'react'
-import {
-  Box,
-  Eye,
-  Heart,
-  Info,
-  Loader2,
-  Minus,
-  Plus,
-  SlidersHorizontal,
-  TriangleAlert,
-} from 'lucide-react'
+import { Box, Eye, Heart, Info, Loader2, Minus, Plus, SlidersHorizontal } from 'lucide-react'
 import type { MapRef } from 'react-map-gl/mapbox'
 import { MapContainer } from '@/components/map/MapContainer'
 import { Sidebar } from '@/components/sidebar/Sidebar'
@@ -24,6 +14,7 @@ import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { useFilterContext, getActiveFilterLabels } from '@/context/FilterContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { toast } from 'sonner'
 
 const mapFallback = (
   <div className="flex h-full w-full items-center justify-center bg-background">
@@ -52,6 +43,18 @@ export function AppShell() {
     return () => clearTimeout(id)
   }, [sidebarOpen, overlayOpen, infoPanelOpen, infoOverlayOpen])
 
+  // Warn if no dates are selected, since that can be confusing. Dismiss when they do select some.
+  useEffect(() => {
+    if (filterState.dateFilter.type === 'none') {
+      toast.warning('No dates selected — use the filters to select a date range', {
+        id: 'no-dates-selected',
+        duration: Infinity,
+      })
+    } else {
+      toast.dismiss('no-dates-selected')
+    }
+  }, [filterState.dateFilter.type])
+
   return (
     <div className="flex w-full h-full">
       {/* Left: info panel (desktop, pinned) */}
@@ -68,16 +71,6 @@ export function AppShell() {
         <ErrorBoundary fallback={mapFallback}>
           <MapContainer ref={mapRef} />
         </ErrorBoundary>
-
-        {/* Top-center: no-date warning banner */}
-        {filterState.dateFilter.type === 'none' && (
-          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 pointer-events-none">
-            <div className="rounded-full bg-background/90 border px-4 py-1.5 text-sm font-medium shadow-sm dark:bg-zinc-900/90 dark:border-zinc-700 flex items-center gap-2 text-warning-foreground">
-              <TriangleAlert className="size-4 text-yellow-600 dark:text-yellow-400" />
-              No dates selected — use the filters to select a date range
-            </div>
-          </div>
-        )}
 
         {/* Top-left: info/about toggle + support */}
         <div className="absolute top-4 left-4 z-10 flex gap-2">

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -16,7 +16,7 @@ interface SidebarProps {
 function FilterContent() {
   const { filterState } = useFilterContext()
   return (
-    <div className="space-y-6 px-4 py-4">
+    <div className="space-y-2 px-4 py-4">
       {filterState.totalCount !== null && (
         <p className="text-sm text-muted-foreground">
           {filterState.totalCount.toLocaleString()} crashes

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -17,6 +17,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps['theme']}
       className="toaster group"
+      position="top-center"
+      offset={32}
+      // On mobile (≤600px) Sonner switches to full-width mode and uses --mobile-offset-*.
+      // Push top offset down enough to clear the top button row (top-4 + h-9 ≈ 52px).
+      mobileOffset={{ top: 80, right: 16, left: 16, bottom: 16 }}
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,

--- a/context/FilterContext.tsx
+++ b/context/FilterContext.tsx
@@ -93,7 +93,7 @@ const initialState: FilterState = {
   mode: null,
   severity: DEFAULT_SEVERITY,
   includeNoInjury: false,
-  dateFilter: { type: 'preset', preset: 'ytd' },
+  dateFilter: { type: 'preset', preset: '90d' },
   state: 'Washington',
   county: null,
   city: null,

--- a/lib/filterUrlState.ts
+++ b/lib/filterUrlState.ts
@@ -57,11 +57,11 @@ export function encodeFilterParams(filterState: FilterState): URLSearchParams {
     params.set('severity', buckets.join(','))
   }
 
-  // dateFilter — omit when it's the default (ytd preset)
+  // dateFilter — omit when it's the default (90d preset)
   const { dateFilter } = filterState
   if (dateFilter.type === 'none') {
     params.set('date', 'none')
-  } else if (dateFilter.type === 'preset' && dateFilter.preset !== 'ytd') {
+  } else if (dateFilter.type === 'preset' && dateFilter.preset !== '90d') {
     params.set('date', dateFilter.preset)
   } else if (dateFilter.type === 'year') {
     params.set('year', String(dateFilter.year))
@@ -69,7 +69,7 @@ export function encodeFilterParams(filterState: FilterState): URLSearchParams {
     params.set('dateFrom', dateFilter.startDate)
     params.set('dateTo', dateFilter.endDate)
   }
-  // preset === 'ytd' → omit (default)
+  // preset === '90d' → omit (default)
 
   // state — omit when it matches the default ('Washington')
   if (filterState.state !== DEFAULT_STATE) {
@@ -124,7 +124,7 @@ export function decodeFilterParams(params: URLSearchParams): UrlFilterState {
   }
 
   // dateFilter
-  let dateFilter: DateFilter = { type: 'preset', preset: 'ytd' }
+  let dateFilter: DateFilter = { type: 'preset', preset: '90d' }
   const rawDate = params.get('date')
   const rawYear = params.get('year')
   const rawDateFrom = params.get('dateFrom')

--- a/lib/graphql/__tests__/queries.test.ts
+++ b/lib/graphql/__tests__/queries.test.ts
@@ -107,17 +107,17 @@ describe('crashes query', () => {
     expect(item.crashDate).toBe('2024-06-15')
   })
 
-  it('caps limit at 5000', async () => {
+  it('caps limit at 10000', async () => {
     mockPrisma.crashData.findMany.mockResolvedValue([])
     mockPrisma.crashData.count.mockResolvedValue(0)
 
     await server.executeOperation({
       query: CRASHES_QUERY,
-      variables: { limit: 10000 },
+      variables: { limit: 20000 },
     })
 
     expect(mockPrisma.crashData.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ take: 5000 })
+      expect.objectContaining({ take: 10000 })
     )
   })
 

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -88,7 +88,7 @@ export const resolvers: Resolvers = {
   Query: {
     crashes: async (_, { filter, limit, offset }) => {
       const where = buildWhere(filter)
-      const cappedLimit = Math.min(limit ?? 1000, 5000)
+      const cappedLimit = Math.min(limit ?? 1000, 10000)
       const [items, totalCount] = await Promise.all([
         prisma.crashData.findMany({ where, skip: offset ?? 0, take: cappedLimit }),
         prisma.crashData.count({ where }),


### PR DESCRIPTION
- Raised the crash display cap from 5,000 to 10,000 (resolver hard cap, `CrashLayer` query variable, and CSV export limit all updated)
- Added a persistent warning toast when `totalCount > 10,000`: "Showing 10,000 of X,XXX crashes — narrow your filters to see all results." (auto-dismisses when filters are narrowed below the limit)
- Repositioned toasts to top-center on desktop; on mobile (≤600px) Sonner's full-width mode is used with `mobileOffset={{ top: 80 }}` to push toasts below the top button row

Closes #154 