### PR TITLE
Raise Display Limit to 40,000

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This project was bootstrapped with [`create-next-app`](https://nextjs.org/docs/a
 
 ## Changelog
 
+### 2026-02-26 — Raise Display Limit to 40,000
+
+- Raised the crash display cap from 10,000 to 40,000 (resolver hard cap, `CrashLayer` `DISPLAY_LIMIT` constant, and CSV export limit); covers the full ~34,000-row dataset without truncation
+
 ### 2026-02-25 — Display Limit & Toast Warning
 
 - Raised the crash display cap from 5,000 to 10,000 (resolver hard cap, `CrashLayer` query variable, and CSV export limit all updated)

--- a/components/export/ExportButton.tsx
+++ b/components/export/ExportButton.tsx
@@ -42,7 +42,7 @@ export function ExportButton({ variant = 'icon' }: ExportButtonProps) {
 
   async function handleExport() {
     const { data } = await fetchCrashes({
-      variables: { filter: toCrashFilter(filterState), limit: 10000 },
+      variables: { filter: toCrashFilter(filterState), limit: 40000 },
     })
     if (!data) return
 

--- a/components/info/InfoPanelContent.tsx
+++ b/components/info/InfoPanelContent.tsx
@@ -144,7 +144,7 @@ export function InfoPanelContent({ onSwitchView }: InfoPanelContentProps) {
       </section>
       <section>
         <p className="text-xs text-muted-foreground/60 mt-0.5">
-          Version 0.6.1 &middot; Updated 2/23/2026
+          Version 0.7.2 &middot; Updated 2/26/2026
         </p>
         <p className="text-xs text-muted-foreground/60 mt-0.5">© Copyright 2026 Nick Magruder</p>
       </section>

--- a/components/map/CrashLayer.tsx
+++ b/components/map/CrashLayer.tsx
@@ -10,7 +10,7 @@ import { GET_CRASHES } from '@/lib/graphql/queries'
 import { useFilterContext, toCrashFilter, type CrashFilterInput } from '@/context/FilterContext'
 import { STANDARD_COLORS, ACCESSIBLE_COLORS } from '@/lib/crashColors'
 
-const DISPLAY_LIMIT = 10_000
+const DISPLAY_LIMIT = 40_000
 const LIMIT_TOAST_ID = 'crash-limit-warning'
 
 type CrashItem = {

--- a/lib/graphql/__tests__/queries.test.ts
+++ b/lib/graphql/__tests__/queries.test.ts
@@ -107,17 +107,17 @@ describe('crashes query', () => {
     expect(item.crashDate).toBe('2024-06-15')
   })
 
-  it('caps limit at 10000', async () => {
+  it('caps limit at 40000', async () => {
     mockPrisma.crashData.findMany.mockResolvedValue([])
     mockPrisma.crashData.count.mockResolvedValue(0)
 
     await server.executeOperation({
       query: CRASHES_QUERY,
-      variables: { limit: 20000 },
+      variables: { limit: 50000 },
     })
 
     expect(mockPrisma.crashData.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ take: 10000 })
+      expect.objectContaining({ take: 40000 })
     )
   })
 

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -88,7 +88,7 @@ export const resolvers: Resolvers = {
   Query: {
     crashes: async (_, { filter, limit, offset }) => {
       const where = buildWhere(filter)
-      const cappedLimit = Math.min(limit ?? 1000, 10000)
+      const cappedLimit = Math.min(limit ?? 1000, 40000)
       const [items, totalCount] = await Promise.all([
         prisma.crashData.findMany({ where, skip: offset ?? 0, take: cappedLimit }),
         prisma.crashData.count({ where }),

--- a/tutorial.md
+++ b/tutorial.md
@@ -6463,14 +6463,16 @@ The `tilted` state is local to `AppShell` — it only drives the button's `varia
 
 ### Why cap the query?
 
-Loading tens of thousands of GeoJSON features into the browser is expensive. We cap the map display at **10,000 crashes** and show a persistent toast when the user's filters exceed that count, prompting them to narrow their search.
+Loading tens of thousands of GeoJSON features into the browser is expensive. We set a hard cap and show a persistent toast when the user's filters exceed it, prompting them to narrow their search.
+
+The cap started at 5,000, was raised to 10,000, and then raised again to **40,000** after confirming acceptable browser performance with the full ~34,000-row Washington dataset. At this limit the toast effectively never fires for the current data, but remains in place as a safety net if the dataset grows.
 
 ### Raising the resolver cap
 
-In `lib/graphql/resolvers.ts`, the `crashes` query already had a hard cap. We raised it from 5,000 to 10,000:
+In `lib/graphql/resolvers.ts`, the `crashes` query has a server-side hard cap:
 
 ```ts
-const cappedLimit = Math.min(limit ?? 1000, 10000)
+const cappedLimit = Math.min(limit ?? 1000, 40000)
 ```
 
 The `totalCount` is always returned (via a parallel `prisma.crashData.count({ where })`), so the client always knows the true total even when results are truncated.
@@ -6480,7 +6482,7 @@ The `totalCount` is always returned (via a parallel `prisma.crashData.count({ wh
 In `components/map/CrashLayer.tsx`, a module-level constant keeps the limit in one place:
 
 ```ts
-const DISPLAY_LIMIT = 10_000
+const DISPLAY_LIMIT = 40_000
 const LIMIT_TOAST_ID = 'crash-limit-warning'
 ```
 


### PR DESCRIPTION
- Raised the crash display cap from 10,000 to 40,000 (resolver hard cap, `CrashLayer` `DISPLAY_LIMIT` constant, and CSV export limit); covers the full ~34,000-row dataset without truncation

Close #156 