### PR TITLE
Filter Sentry Browser Extension Noise

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -817,14 +817,14 @@ Set `output: 'standalone'` in `next.config.ts` for optimal builds on Render (alr
 
 ### Development & DevOps
 
-| Purpose        | Tool                                          |
-| -------------- | --------------------------------------------- |
-| Local DB       | Docker + `postgis/postgis` image              |
-| API Playground | Apollo Sandbox (built into Apollo Server)     |
-| Error Tracking | Sentry                                        |
-| CI/CD          | GitHub Actions                                |
-| Hosting        | Render (app + database — all on one platform) |
-| Monitoring     | Sentry (errors) + Lighthouse CI (web vitals)  |
+| Purpose        | Tool                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------ |
+| Local DB       | Docker + `postgis/postgis` image                                                     |
+| API Playground | Apollo Sandbox (built into Apollo Server)                                            |
+| Error Tracking | Sentry                                                                               |
+| CI/CD          | GitHub Actions                                                                       |
+| Hosting        | Render (app + database — all on one platform)                                        |
+| Monitoring     | Sentry (errors) + Lighthouse CI (web vitals) + Better Stack (infrastructure metrics) |
 
 ### Documentation & Learning
 
@@ -851,14 +851,15 @@ Set `output: 'standalone'` in `next.config.ts` for optimal builds on Render (alr
 | **Largest Contentful Paint (LCP)**    | < 2.5s                                                      | Web Vitals                |
 | **Map initial render**                | < 2s with full dataset loaded                               | Browser performance marks |
 | **Error rate**                        | < 0.1%                                                      | Sentry                    |
+| **CPU / memory / uptime**             | CPU < 80% sustained; uptime > 99.9%                         | Better Stack              |
 
 ### Evaluation Cadence
 
 Given low daily traffic, a lightweight evaluation approach is appropriate:
 
 - **After deployment:** Run Lighthouse, test all filters, verify map rendering with full dataset
-- **Monthly:** Check Sentry for errors, run Lighthouse for any performance regressions
-- **After data imports:** Verify query performance hasn't degraded as the dataset grows
+- **Monthly:** Check Sentry for errors, review Better Stack metrics dashboard for CPU/memory trends, run Lighthouse for any performance regressions
+- **After data imports:** Verify query performance hasn't degraded as the dataset grows; check Better Stack for memory spikes during import
 
 ### User Feedback Loop
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,14 @@ This project is developed in the open. To report issues or suggest features, ple
 
 ## Changelog
 
+### 2026-03-04 — Filter Sentry Browser Extension Noise
+
+- Added `beforeSend` hook to `instrumentation-client.ts` to drop Sentry events caused by browser extensions: Firefox Reader Mode (`window.__firefox__`) and crypto wallet extensions (`window.ethereum`); checks both `hint.originalException.message` and `event.exception.values[0].value` to catch all event shapes
+
+### 2026-03-04 — Better Stack Metrics Stream
+
+- Connected Better Stack as a Render metrics stream (Render dashboard → Log & Metrics → Configure metrics) for both `crashmap` and `crashmap-staging`; streams infrastructure metrics (CPU, memory, HTTP response times, uptime)
+
 ### 2026-02-26 — Raise Display Limit to 40,000
 
 - Raised the crash display cap from 10,000 to 40,000 (resolver hard cap, `CrashLayer` `DISPLAY_LIMIT` constant, and CSV export limit); covers the full ~34,000-row dataset without truncation
@@ -390,6 +398,16 @@ This project is developed in the open. To report issues or suggest features, ple
 - Clicking from one crash to another while a popup is open flies to the new crash but keeps the original viewport for the eventual restore
 - Implemented with `useImperativeHandle` so the existing external `mapRef` used by `AppShell` for `map.resize()` continues to work unchanged; a `savedViewportRef` (not state) stores the captured viewport without triggering re-renders
 
+### 2026-02-23 — Monitoring (Sentry + Lighthouse CI)
+
+- Installed `@sentry/nextjs` and ran Sentry wizard; configured `instrumentation-client.ts` (client, Session Replay), `sentry.server.config.ts`, `sentry.edge.config.ts`, `instrumentation.ts` (`onRequestError`), and `app/global-error.tsx`
+- Added `consoleLoggingIntegration({ levels: ['log', 'warn', 'error'] })` and `enableLogs: true` to all three Sentry init files — forwards `console.log/warn/error` calls to Sentry Logs
+- DSN stored in `NEXT_PUBLIC_SENTRY_DSN` env var; declared in `render.yaml` for both services and set in Render dashboard; `SENTRY_AUTH_TOKEN` added as GitHub Actions secret and exposed in the CI build step env for source-map uploads
+- Added `tunnelRoute: "/monitoring"` to `withSentryConfig` to bypass ad blockers; updated `connect-src` CSP to include `*.ingest.sentry.io` and `*.ingest.us.sentry.io` as fallback
+- Updated `app/error.tsx` to call `Sentry.captureException` instead of `console.error`
+- Added Lighthouse CI: `.lighthouserc.json` targeting `https://crashmap.io`; `lighthouse` job in `ci.yml` runs after `deploy` on `main`, uploads report to temporary public storage (report-only, never fails CI)
+- Fixed `FilterUrlSync` sub-route redirect bug: `router.replace` now uses `usePathname()` to preserve the current path instead of always replacing to `/`
+
 ### 2026-02-20 — Summary Bar Redesign and Emoji Mode Badges
 
 - `SummaryBar` mobile layout changed to a fixed full-width strip flush against the viewport bottom (`fixed bottom-0 left-0 right-0`), minimal height, no rounded corners; desktop changed to a `rounded-md` bar close to the bottom edge (`bottom-3`) with tighter padding
@@ -437,6 +455,12 @@ This project is developed in the open. To report issues or suggest features, ple
 - Added `components/FilterUrlSync.tsx` — invisible client component that syncs URL ↔ `FilterContext` via two effects: mount reads URL → `INIT_FROM_URL` dispatch; subsequent filter changes → `router.replace` (no history pollution); `skipFirstSyncRef` prevents the initial render from overwriting an incoming shared URL with defaults
 - Added `INIT_FROM_URL` action and `UrlFilterState` exported type to `context/FilterContext.tsx` — atomic state write that bypasses cascading reset logic
 - Wired `<FilterUrlSync />` in `app/layout.tsx` inside `<Suspense fallback={null}>` within `FilterProvider` (required by `useSearchParams` in the App Router)
+
+### 2026-02-19 — Error Boundaries
+
+- Added `components/ErrorBoundary.tsx` — reusable React class component with a `fallback` prop; logs caught errors to console via `componentDidCatch`
+- Added `app/error.tsx` — Next.js route-level error page with a "Try again" reset button
+- Applied boundaries in `AppShell`: `MapContainer` gets a "Map failed to load / Refresh" full-screen fallback; `Sidebar` + `FilterOverlay` silently suppress (`fallback={null}`) so the map stays usable if filters crash
 
 ### 2026-02-19 — Skeleton Screens
 
@@ -739,19 +763,3 @@ This project is developed in the open. To report issues or suggest features, ple
 - Refined generated Prisma model: renamed to `CrashData`, added camelCase field names with `@map` decorators and `@@map("crashdata")`
 - Ran `npx prisma generate` to produce typed client in `lib/generated/prisma/`
 - Added `lib/generated/prisma` to `.gitignore`
-
-### 2026-02-23 — Monitoring (Sentry + Lighthouse CI)
-
-- Installed `@sentry/nextjs` and ran Sentry wizard; configured `instrumentation-client.ts` (client, Session Replay), `sentry.server.config.ts`, `sentry.edge.config.ts`, `instrumentation.ts` (`onRequestError`), and `app/global-error.tsx`
-- Added `consoleLoggingIntegration({ levels: ['log', 'warn', 'error'] })` and `enableLogs: true` to all three Sentry init files — forwards `console.log/warn/error` calls to Sentry Logs
-- DSN stored in `NEXT_PUBLIC_SENTRY_DSN` env var; declared in `render.yaml` for both services and set in Render dashboard; `SENTRY_AUTH_TOKEN` added as GitHub Actions secret and exposed in the CI build step env for source-map uploads
-- Added `tunnelRoute: "/monitoring"` to `withSentryConfig` to bypass ad blockers; updated `connect-src` CSP to include `*.ingest.sentry.io` and `*.ingest.us.sentry.io` as fallback
-- Updated `app/error.tsx` to call `Sentry.captureException` instead of `console.error`
-- Added Lighthouse CI: `.lighthouserc.json` targeting `https://crashmap.io`; `lighthouse` job in `ci.yml` runs after `deploy` on `main`, uploads report to temporary public storage (report-only, never fails CI)
-- Fixed `FilterUrlSync` sub-route redirect bug: `router.replace` now uses `usePathname()` to preserve the current path instead of always replacing to `/`
-
-### 2026-02-19 — Error Boundaries
-
-- Added `components/ErrorBoundary.tsx` — reusable React class component with a `fallback` prop; logs caught errors to console via `componentDidCatch`
-- Added `app/error.tsx` — Next.js route-level error page with a "Try again" reset button
-- Applied boundaries in `AppShell`: `MapContainer` gets a "Map failed to load / Refresh" full-screen fallback; `Sidebar` + `FilterOverlay` silently suppress (`fallback={null}`) so the map stays usable if filters crash

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -7,6 +7,18 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
+  beforeSend(event, hint) {
+    const error = hint?.originalException
+    const hintMsg = error instanceof Error ? error.message : String(error ?? '')
+    const eventMsg = event.exception?.values?.[0]?.value ?? ''
+    const combined = hintMsg + ' ' + eventMsg
+    // Ignore Firefox Reader Mode and browser extension noise
+    if (combined.includes('__firefox__') || combined.includes('window.ethereum')) {
+      return null
+    }
+    return event
+  },
+
   // Add optional integrations for additional features
   integrations: [
     Sentry.replayIntegration(),

--- a/tutorial.md
+++ b/tutorial.md
@@ -4696,7 +4696,7 @@ export async function POST(request: NextRequest) {
 
 Note that `Access-Control-Allow-Origin` must be a single origin value (not a list) when `Access-Control-Allow-Credentials` is involved. Since we don't use credentials, we could use `*` — but reflecting the requesting origin from an allowlist gives us more control.
 
-#### Verify
+#### Verify It
 
 Run `npm run build` to confirm TypeScript and the build both pass. Then start the dev server and open the browser DevTools Network tab — every HTML and API response should now carry the security headers. You can verify CSP enforcement by temporarily adding an inline script that tries to call `eval()` and observing the console error.
 
@@ -6432,7 +6432,38 @@ Render polls the health check path every 10 seconds. If it returns a non-2xx sta
 
 ---
 
-### Step 6: Adding a Support Panel
+### Step 6: Better Stack — Infrastructure Metrics
+
+Sentry covers application errors and Lighthouse covers web vitals. What's still missing is infrastructure-level visibility: CPU usage, memory, HTTP response times, and uptime. Render exposes a native metrics stream that can forward this data to an external provider.
+
+#### Why Better Stack
+
+Render supports several metrics destinations: Better Stack, Datadog, Grafana Cloud, Groundcover, Honeycomb, New Relic, and Signoz. For a low-traffic solo-operated app that already has Sentry for errors, Better Stack is the best fit:
+
+- Most generous free tier for small projects (logs + uptime + metrics in one product)
+- Render's native integration is first-class and well-documented
+- Low operational overhead — no dashboards to configure from scratch
+
+Grafana Cloud and New Relic are stronger choices if you anticipate significant growth or want open-source portability, but are heavier to set up.
+
+#### Connect the metrics stream
+
+1. Create a free account at [betterstack.com](https://betterstack.com) if you don't have one
+2. In the Better Stack dashboard, go to **Telemetry** → **Sources** → **Connect source** → select **Render**
+3. Copy the ingestion endpoint URL and the source token that Better Stack provides
+4. In the Render dashboard, open the `crashmap` web service → **Log & Metrics** → **Configure metrics**
+5. Select **Better Stack** as the destination, paste the endpoint and token, and save
+6. Repeat for `crashmap-staging`
+
+Render will begin streaming CPU percentage, memory usage, HTTP request count, response time percentiles, and service uptime to Better Stack within a few minutes of the next deploy.
+
+#### Verify the connection
+
+After the next deploy completes, open your Better Stack **Telemetry** dashboard and confirm metrics are flowing. You should see CPU and memory graphs within 5–10 minutes.
+
+---
+
+### Step 7: Adding a Support Panel
 
 #### Why
 
@@ -6458,7 +6489,7 @@ The top map buttons use `variant="outline"` which picks up `border-input` in dar
 
 ---
 
-### Step 7: Accessible Color Scale
+### Step 8: Accessible Color Scale
 
 Map dots rely on color to communicate severity — which is a problem for the ~8% of males with red-green color blindness who can't distinguish the standard dark-red / orange / yellow / green scale. We add a toggle that swaps to the **Paul Tol Muted** palette, a scheme specifically engineered to be distinguishable under all forms of color vision deficiency (protanopia, deuteranopia, tritanopia).
 
@@ -6496,7 +6527,7 @@ The result: users can enable the accessible palette from either the map toolbar 
 
 ---
 
-### Step 8: Date Filter Overhaul
+### Step 9: Date Filter Overhaul
 
 #### Establishing a React file structure convention
 
@@ -6596,7 +6627,7 @@ Text inputs also fire a format error toast when the user types exactly 10 charac
 
 ---
 
-### Step 9: Date Filter — shadcn Range Calendar Refactor
+### Step 10: Date Filter — shadcn Range Calendar Refactor
 
 #### Overview
 
@@ -6698,7 +6729,7 @@ Rather than a transient toast, render a conditional banner absolutely positioned
 
 ---
 
-### Step 10: Date Filter — Named Preset Buttons
+### Step 11: Date Filter — Named Preset Buttons
 
 Instead of hardcoded year buttons (2025, 2024, …), the date filter now uses four dynamic named presets that always reflect the actual available data.
 
@@ -6878,7 +6909,7 @@ Clicking an active preset button toggles it off (dispatches `CLEAR_DATE`), consi
 
 ---
 
-### Step 11: Popup Centering with Mapbox Padding
+### Step 12: Popup Centering with Mapbox Padding
 
 When a crash is clicked, the map flies to center on the crash coordinates. But since the popup anchors at the bottom of the crash point and renders upward, it can overlap the UI buttons at the top of the screen — especially on mobile.
 
@@ -6895,7 +6926,7 @@ map.flyTo({ center: coords, zoom: targetZoom, pitch: 45, padding, duration: 800 
 
 The `bottom: 70` on mobile accounts for the fixed SummaryBar strip at the bottom of the viewport (~44px + buffer). When the popup closes and the viewport is restored, padding must be explicitly reset to `{ top: 0, bottom: 0, left: 0, right: 0 }` — Mapbox retains the padding state across `flyTo` calls.
 
-### Step 12: Metered Zoom
+### Step 13: Metered Zoom
 
 Jumping straight to zoom 15.5 on every crash click is jarring when the user starts from a state-level view (zoom 7–10). A better UX is to fly halfway to the target zoom, so the user lands at a contextually appropriate level and can click again to go deeper if needed.
 
@@ -6909,7 +6940,7 @@ map.flyTo({ center: coords, zoom: newZoom, ... })
 
 For crash-to-crash clicks (clicking a new crash without closing the popup), `savedViewportRef` is NOT updated — it retains the original pre-popup zoom. This keeps the depth consistent: every crash click from a given starting position lands at the same zoom level, regardless of how many crashes the user has clicked through.
 
-### Step 13: Retaining User Camera Moves During Popup
+### Step 14: Retaining User Camera Moves During Popup
 
 If the user pans or zooms while a popup is open, the saved viewport should update so that dismissing the popup returns to their new position rather than the original one.
 
@@ -6942,7 +6973,7 @@ const handleMoveEnd = useCallback(() => {
 
 Both `flyTo` call sites (popup open and popup close) must set the flag — missing either one causes the saved viewport to get corrupted by the animation's `moveend` event.
 
-### Step 14: Tilt Toggle and Zoom Buttons
+### Step 15: Tilt Toggle and Zoom Buttons
 
 Standard map controls (zoom in/out, tilt toggle) live in `AppShell` at `absolute bottom-14 left-4 md:bottom-6` — above the fixed mobile SummaryBar. They use the same shadcn `Button` `variant="outline"` styling as all other floating controls.
 
@@ -6962,7 +6993,7 @@ The `tilted` state is local to `AppShell` — it only drives the button's `varia
 
 ---
 
-### Step 15: Display Limit & Warning Toast
+### Step 16: Display Limit & Warning Toast
 
 #### Why cap the query?
 


### PR DESCRIPTION
- Added `beforeSend` hook to `instrumentation-client.ts` to drop Sentry events caused by browser extensions: Firefox Reader Mode (`window.__firefox__`) and crypto wallet extensions (`window.ethereum`); checks both `hint.originalException.message` and `event.exception.values[0].value` to catch all event shapes

Closes #168 
Closes #169