### PR TITLE
Fix sentry noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,3 +763,8 @@ This project is developed in the open. To report issues or suggest features, ple
 - Refined generated Prisma model: renamed to `CrashData`, added camelCase field names with `@map` decorators and `@@map("crashdata")`
 - Ran `npx prisma generate` to produce typed client in `lib/generated/prisma/`
 - Added `lib/generated/prisma` to `.gitignore`
+
+### 2026-03-08 — Sentry Noise Filtering & Spurious Navigation Fix
+
+- Fixed `FilterUrlSync` spurious same-URL `router.replace` — added early-return guard when encoded params match current `searchParams`; prevents redundant RSC fetches and downstream Mapbox worker errors on every page load
+- Expanded Sentry `beforeSend` noise filters: added `runtime.sendMessage` (Safari extension), `CustomEvent` exception type (Mapbox GL tile/worker rejections), and `InvalidStateError` + "The object is in an invalid state." (Mapbox GL worker termination)

--- a/components/FilterUrlSync.tsx
+++ b/components/FilterUrlSync.tsx
@@ -41,8 +41,10 @@ export function FilterUrlSync() {
     }
     const params = encodeFilterParams(filterState)
     const search = params.toString()
+    // Skip if the URL would be unchanged — avoids spurious RSC navigations
+    if (search === searchParams.toString()) return
     router.replace(search ? `${pathname}?${search}` : pathname, { scroll: false })
-  }, [filterState, router, pathname])
+  }, [filterState, router, pathname, searchParams])
 
   return null
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -11,9 +11,28 @@ Sentry.init({
     const error = hint?.originalException
     const hintMsg = error instanceof Error ? error.message : String(error ?? '')
     const eventMsg = event.exception?.values?.[0]?.value ?? ''
+    const exceptionType = event.exception?.values?.[0]?.type ?? ''
     const combined = hintMsg + ' ' + eventMsg
-    // Ignore Firefox Reader Mode and browser extension noise
-    if (combined.includes('__firefox__') || combined.includes('window.ethereum')) {
+    // Ignore Firefox Reader Mode, wallet extensions, and Safari extension noise
+    if (
+      combined.includes('__firefox__') ||
+      combined.includes('window.ethereum') ||
+      combined.includes('runtime.sendMessage')
+    ) {
+      return null
+    }
+    // Ignore Mapbox GL worker/tile failures — they reject with CustomEvent objects
+    // rather than real Errors and are not actionable application errors
+    if (exceptionType === 'CustomEvent') {
+      return null
+    }
+    // Ignore Mapbox GL worker termination errors — postMessage on a terminated worker
+    // throws "The object is in an invalid state." (DOMException InvalidStateError);
+    // occurs when the Map component unmounts while tile-fetch callbacks are still queued
+    if (
+      exceptionType === 'InvalidStateError' &&
+      eventMsg === 'The object is in an invalid state.'
+    ) {
       return null
     }
     return event


### PR DESCRIPTION
- Fixed `FilterUrlSync` spurious same-URL `router.replace` — added early-return guard when encoded params match current `searchParams`; prevents redundant RSC fetches and downstream Mapbox worker errors on every page load
- Expanded Sentry `beforeSend` noise filters: added `runtime.sendMessage` (Safari extension), `CustomEvent` exception type (Mapbox GL tile/worker rejections), and `InvalidStateError` + "The object is in an invalid state." (Mapbox GL worker termination)

Closes #172
Closes #173
Closes #174 