### PR TITLE
Start Accessibility Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,14 @@ This project is developed in the open. To report issues or suggest features, ple
 - Imported February 2026 crash data: 43 pedestrian + 8 bicyclist records (51 total; EG82570 missing coordinates)
 - Added post-import checklist steps to `data-pipeline.md`: update `InfoPanelContent.tsx` data range and log entry after each ingestion
 
+### 2026-03-08 — WCAG 2.1 AA Accessibility Improvements (Phase 8.1)
+
+- Added skip link ("Skip to main content") at top of `app/layout.tsx` — visually hidden, visible on focus, jumps to `#map-region`
+- Added `id="map-region"` + `role="main"` to map container in `AppShell.tsx`; added `aria-label="Crash data map"` to Mapbox `<Map>`
+- Added explicit `<label>` elements for County and City dropdowns in `GeographicFilter.tsx` with matching `id` on `SelectTrigger`
+- Both mobile overlays (`FilterOverlay`, `InfoOverlay`) now use `aria-labelledby` pointing to heading `id`, close on Escape, move focus to close button on open, and restore focus to the trigger button on close
+- Fixed copy-report-number button in `CrashPopup.tsx` — replaced mouse-only `title` with dynamic `aria-label`; both icon variants marked `aria-hidden`
+
 ### 2026-03-08 — Sentry Noise Filtering & Spurious Navigation Fix
 
 - Fixed `FilterUrlSync` spurious same-URL `router.replace` — added early-return guard when encoded params match current `searchParams`; prevents redundant RSC fetches and downstream Mapbox worker errors on every page load

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,6 +43,12 @@ export default function RootLayout({
         >
           <ApolloProvider>
             <FilterProvider>
+              <a
+                href="#map-region"
+                className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:rounded focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:shadow-md focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                Skip to main content
+              </a>
               <Suspense fallback={null}>
                 <FilterUrlSync />
               </Suspense>

--- a/components/filters/GeographicFilter.tsx
+++ b/components/filters/GeographicFilter.tsx
@@ -88,12 +88,15 @@ export function GeographicFilter() {
           )}
         </div>
 
+        <Label htmlFor="county-select" className="text-xs text-muted-foreground">
+          County
+        </Label>
         <Select
           value={filterState.county ?? ALL}
           onValueChange={handleCountyChange}
           disabled={isDisabled || counties.length === 0}
         >
-          <SelectTrigger className="w-full">
+          <SelectTrigger id="county-select" className="w-full">
             <SelectValue placeholder="All counties" />
           </SelectTrigger>
           <SelectContent>
@@ -106,12 +109,15 @@ export function GeographicFilter() {
           </SelectContent>
         </Select>
 
+        <Label htmlFor="city-select" className="text-xs text-muted-foreground">
+          City
+        </Label>
         <Select
           value={filterState.city ?? ALL}
           onValueChange={handleCityChange}
           disabled={isDisabled || cities.length === 0}
         >
-          <SelectTrigger className="w-full">
+          <SelectTrigger id="city-select" className="w-full">
             <SelectValue placeholder="All cities" />
           </SelectTrigger>
           <SelectContent>

--- a/components/info/InfoOverlay.tsx
+++ b/components/info/InfoOverlay.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { InfoPanelContent } from './InfoPanelContent'
@@ -14,6 +15,21 @@ interface InfoOverlayProps {
 }
 
 export function InfoOverlay({ isOpen, onClose, view = 'info', onSwitchView }: InfoOverlayProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (isOpen) closeButtonRef.current?.focus()
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
   if (!isOpen) return null
 
   return (
@@ -21,11 +37,19 @@ export function InfoOverlay({ isOpen, onClose, view = 'info', onSwitchView }: In
       className="fixed inset-0 z-20 flex flex-col bg-background md:hidden"
       role="dialog"
       aria-modal="true"
-      aria-label="About"
+      aria-labelledby="info-overlay-title"
     >
       <div className="flex items-center justify-between border-b px-4 py-3">
-        <h2 className="text-base font-semibold">💥CrashMap</h2>
-        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+        <h2 id="info-overlay-title" className="text-base font-semibold">
+          <span aria-hidden="true">💥</span>CrashMap
+        </h2>
+        <Button
+          ref={closeButtonRef}
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          aria-label="Close"
+        >
           <X className="size-4" />
         </Button>
       </div>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -35,6 +35,8 @@ export function AppShell() {
   const [infoPanelView, setInfoPanelView] = useState<InfoPanelView>('info')
   const [tilted, setTilted] = useState(false)
   const mapRef = useRef<MapRef>(null)
+  const filterTriggerRef = useRef<HTMLButtonElement>(null)
+  const infoTriggerRef = useRef<HTMLButtonElement>(null)
   const { filterState, dispatch } = useFilterContext()
 
   // Call resize() after any panel transition so Mapbox recomputes canvas size.
@@ -42,6 +44,18 @@ export function AppShell() {
     const id = setTimeout(() => mapRef.current?.resize(), 0)
     return () => clearTimeout(id)
   }, [sidebarOpen, overlayOpen, infoPanelOpen, infoOverlayOpen])
+
+  // Restore focus to trigger buttons when mobile overlays close.
+  const prevOverlayOpenRef = useRef(false)
+  const prevInfoOverlayOpenRef = useRef(false)
+  useEffect(() => {
+    if (prevOverlayOpenRef.current && !overlayOpen) filterTriggerRef.current?.focus()
+    prevOverlayOpenRef.current = overlayOpen
+  }, [overlayOpen])
+  useEffect(() => {
+    if (prevInfoOverlayOpenRef.current && !infoOverlayOpen) infoTriggerRef.current?.focus()
+    prevInfoOverlayOpenRef.current = infoOverlayOpen
+  }, [infoOverlayOpen])
 
   // Warn if no dates are selected, since that can be confusing. Dismiss when they do select some.
   useEffect(() => {
@@ -67,7 +81,7 @@ export function AppShell() {
       )}
 
       {/* Center: map + overlays + controls */}
-      <div className="flex-1 relative" style={{ minWidth: 0 }}>
+      <div id="map-region" role="main" className="flex-1 relative" style={{ minWidth: 0 }}>
         <ErrorBoundary fallback={mapFallback}>
           <MapContainer ref={mapRef} />
         </ErrorBoundary>
@@ -104,6 +118,7 @@ export function AppShell() {
           {/* Mobile version */}
           <div className="md:hidden flex gap-2">
             <Button
+              ref={infoTriggerRef}
               variant="outline"
               size="icon"
               className="dark:bg-zinc-900 dark:border-zinc-700"
@@ -175,6 +190,7 @@ export function AppShell() {
           {/* Filter overlay toggle — mobile only */}
           <div className="md:hidden">
             <Button
+              ref={filterTriggerRef}
               variant="outline"
               size="icon"
               className="dark:bg-zinc-900 dark:border-zinc-700"

--- a/components/map/CrashPopup.tsx
+++ b/components/map/CrashPopup.tsx
@@ -116,10 +116,14 @@ export function CrashPopup({ crash, onClose }: CrashPopupProps) {
             </span>
             <button
               onClick={() => handleCopyReportNum(crash.colliRptNum!)}
-              title="Copy report number"
+              aria-label={copied ? 'Report number copied' : 'Copy report number'}
               style={{ color: 'var(--muted-foreground)', lineHeight: 1 }}
             >
-              {copied ? <Check size={11} /> : <Copy size={11} />}
+              {copied ? (
+                <Check size={11} aria-hidden="true" />
+              ) : (
+                <Copy size={11} aria-hidden="true" />
+              )}
             </button>
           </div>
         )}

--- a/components/map/MapContainer.tsx
+++ b/components/map/MapContainer.tsx
@@ -145,6 +145,7 @@ export const MapContainer = forwardRef<MapRef>(function MapContainer(_, ref) {
       interactiveLayerIds={['crashes-none', 'crashes-minor', 'crashes-major', 'crashes-death']}
       onClick={handleMapClick}
       onMoveEnd={handleMoveEnd}
+      aria-label="Crash data map"
     >
       <CrashLayer />
       {selectedCrash && <CrashPopup crash={selectedCrash} onClose={closePopup} />}

--- a/components/overlay/FilterOverlay.tsx
+++ b/components/overlay/FilterOverlay.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ModeToggle } from '@/components/filters/ModeToggle'
@@ -16,6 +17,21 @@ interface FilterOverlayProps {
 
 export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
   const { filterState } = useFilterContext()
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (isOpen) closeButtonRef.current?.focus()
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
   if (!isOpen) return null
 
   return (
@@ -23,18 +39,26 @@ export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
       className="fixed inset-0 z-20 flex flex-col bg-background md:hidden"
       role="dialog"
       aria-modal="true"
-      aria-label="Filters"
+      aria-labelledby="filter-overlay-title"
     >
       <div className="flex items-center justify-between border-b px-4 py-3">
         <div>
-          <h2 className="text-base font-semibold">Filters</h2>
+          <h2 id="filter-overlay-title" className="text-base font-semibold">
+            Filters
+          </h2>
           {filterState.totalCount !== null && (
             <p className="text-xs text-muted-foreground">
               {filterState.totalCount.toLocaleString()} crashes
             </p>
           )}
         </div>
-        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close filters">
+        <Button
+          ref={closeButtonRef}
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          aria-label="Close filters"
+        >
           <X className="size-4" />
         </Button>
       </div>

--- a/tutorial.md
+++ b/tutorial.md
@@ -7380,4 +7380,198 @@ For the full operator workflow (routine monthly imports, troubleshooting, valida
 
 ---
 
+## Phase 8: Accessibility Audit (WCAG 2.1 AA)
+
+CrashMap is a public-facing safety tool. Anyone should be able to use it — including people who navigate with a keyboard only, or who use a screen reader. This phase works through the WCAG 2.1 AA standard systematically: critical structural requirements first, then high-priority announcements and labels, then medium-priority polish.
+
+The Mapbox map itself is inherently inaccessible to screen readers (it's a canvas-like element), but everything around it — the filters, overlays, export, and controls — can and should be fully accessible. That's where this phase focuses.
+
+### Step 1: Critical Fixes
+
+The critical fixes address the structural requirements that screen reader and keyboard users rely on most: where focus lands, whether dialogs are announced, and whether form controls have names.
+
+#### Skip Link
+
+A visually-hidden skip link lets keyboard users jump past all the controls directly to the map region — the same way sighted users can just click the map. Without it, a keyboard user must tab through every button before reaching the content.
+
+Add it as the first element inside `<FilterProvider>` in `app/layout.tsx`:
+
+```tsx
+<a
+  href="#map-region"
+  className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:rounded focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:shadow-md focus:outline-none focus:ring-2 focus:ring-ring"
+>
+  Skip to main content
+</a>
+```
+
+`sr-only` hides it visually. `focus:not-sr-only` makes it fully visible when a keyboard user tabs to it and it receives focus. The `focus:ring-2` gives it a clear focus indicator consistent with the rest of the shadcn/ui design system.
+
+#### Main Landmark and Map Label
+
+The skip link needs a target. Add `id="map-region"` and `role="main"` to the center container div in `AppShell.tsx`:
+
+```tsx
+<div id="map-region" role="main" className="flex-1 relative" style={{ minWidth: 0 }}>
+```
+
+`role="main"` marks this as the primary content landmark — screen readers expose landmark regions in a navigation menu, so this lets users jump directly to the map area without using the skip link.
+
+Add `aria-label="Crash data map"` to the `<Map>` element in `MapContainer.tsx`. Mapbox renders its own `<canvas>` internally; without a label, the map is an anonymous element from the screen reader's perspective:
+
+```tsx
+<Map
+  ...
+  aria-label="Crash data map"
+>
+```
+
+#### Form Labels for Filter Dropdowns
+
+The County and City dropdowns in `GeographicFilter.tsx` were previously unlabeled — screen readers would announce "button, collapsed" with no context. shadcn's `SelectTrigger` accepts an `id` prop, so we can link a standard `<Label>` to it with `htmlFor`:
+
+```tsx
+<Label htmlFor="county-select" className="text-xs text-muted-foreground">
+  County
+</Label>
+<Select ...>
+  <SelectTrigger id="county-select" className="w-full">
+    <SelectValue placeholder="All counties" />
+  </SelectTrigger>
+  ...
+</Select>
+
+<Label htmlFor="city-select" className="text-xs text-muted-foreground">
+  City
+</Label>
+<Select ...>
+  <SelectTrigger id="city-select" className="w-full">
+    ...
+  </SelectTrigger>
+  ...
+</Select>
+```
+
+`Label` was already imported. Clicking the label text now activates the dropdown, and screen readers announce "County, button, collapsed" — giving full context.
+
+#### Mobile Overlay Accessibility
+
+Both mobile overlays (`FilterOverlay` and `InfoOverlay`) already had `role="dialog"` and `aria-modal="true"`, but were missing three things: a dialog name, keyboard dismissal, and focus management.
+
+**Dialog name:** Replace `aria-label` with `aria-labelledby` pointing to the heading:
+
+```tsx
+// Before
+<div role="dialog" aria-modal="true" aria-label="Filters">
+  <h2>Filters</h2>
+
+// After
+<div role="dialog" aria-modal="true" aria-labelledby="filter-overlay-title">
+  <h2 id="filter-overlay-title">Filters</h2>
+```
+
+This is preferred over `aria-label` because the visible heading text is the source of truth — the name is derived from actual content rather than duplicating it.
+
+**Escape key:** Keyboard users expect Escape to close dialogs. Add a keydown listener that is active only when the overlay is open:
+
+```tsx
+useEffect(() => {
+  if (!isOpen) return
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onClose()
+  }
+  document.addEventListener('keydown', handleKeyDown)
+  return () => document.removeEventListener('keydown', handleKeyDown)
+}, [isOpen, onClose])
+```
+
+**Focus on open:** When an overlay opens, focus should move into it immediately — otherwise screen reader users don't know the dialog appeared. Add a `ref` to the close button and focus it when `isOpen` becomes true:
+
+```tsx
+const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+useEffect(() => {
+  if (isOpen) closeButtonRef.current?.focus()
+}, [isOpen])
+
+// ...
+
+<Button ref={closeButtonRef} variant="ghost" size="icon" onClick={onClose} aria-label="Close filters">
+```
+
+The close button is a sensible first focus target — it's the first interactive element and gives the user an immediate escape route.
+
+**Important:** All three hooks must be called unconditionally, before the `if (!isOpen) return null` early return. React's rules of hooks require hooks to run in the same order on every render:
+
+```tsx
+export function FilterOverlay({ isOpen, onClose }: FilterOverlayProps) {
+  const { filterState } = useFilterContext()
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => { ... }, [isOpen])           // focus on open
+  useEffect(() => { ... }, [isOpen, onClose])  // Escape key
+
+  if (!isOpen) return null  // early return AFTER hooks
+
+  return ( ... )
+}
+```
+
+**Focus restoration on close:** When the overlay closes, focus should return to the button that opened it — otherwise keyboard focus is lost and the user has to find their place again. In `AppShell.tsx`, add refs to the mobile trigger buttons and track the previous open state:
+
+```tsx
+const filterTriggerRef = useRef<HTMLButtonElement>(null)
+const infoTriggerRef = useRef<HTMLButtonElement>(null)
+
+const prevOverlayOpenRef = useRef(false)
+const prevInfoOverlayOpenRef = useRef(false)
+
+useEffect(() => {
+  if (prevOverlayOpenRef.current && !overlayOpen) filterTriggerRef.current?.focus()
+  prevOverlayOpenRef.current = overlayOpen
+}, [overlayOpen])
+
+useEffect(() => {
+  if (prevInfoOverlayOpenRef.current && !infoOverlayOpen) infoTriggerRef.current?.focus()
+  prevInfoOverlayOpenRef.current = infoOverlayOpen
+}, [infoOverlayOpen])
+```
+
+The `prevOpenRef` guard prevents the effect from firing focus on the initial render (when both `prevOpen` and `open` are false).
+
+Attach the refs to the mobile trigger buttons:
+
+```tsx
+<Button ref={filterTriggerRef} onClick={() => setOverlayOpen(true)} aria-label="Open filters">
+<Button ref={infoTriggerRef} onClick={() => setInfoOverlayOpen(true)} aria-label="Open about">
+```
+
+#### Copy Button in Crash Popup
+
+The copy-report-number button in `CrashPopup.tsx` used `title="Copy report number"` for its label. `title` is mouse-only — screen readers don't reliably read it, and it doesn't change when the copy succeeds. Replace it with a dynamic `aria-label` and add `aria-hidden` to the icons:
+
+```tsx
+// Before
+<button title="Copy report number">
+  {copied ? <Check size={11} /> : <Copy size={11} />}
+</button>
+
+// After
+<button aria-label={copied ? 'Report number copied' : 'Copy report number'}>
+  {copied ? <Check size={11} aria-hidden="true" /> : <Copy size={11} aria-hidden="true" />}
+</button>
+```
+
+When the user copies the report number, the `aria-label` changes to "Report number copied" — screen readers will re-read the button label, announcing the confirmation. The icons are marked `aria-hidden` because the button's accessible name already comes from the label.
+
+### Step 2: High-Priority Fixes
+
+### Step 3: Medium-Priority Fixes
+
+### Step 4: Verification
+
+### Summary
+
+---
+
 _This tutorial is a work in progress. More steps will be added as the project progresses._


### PR DESCRIPTION
- Added skip link ("Skip to main content") at top of `app/layout.tsx` — visually hidden, visible on focus, jumps to `#map-region`
- Added `id="map-region"` + `role="main"` to map container in `AppShell.tsx`; added `aria-label="Crash data map"` to Mapbox `<Map>`
- Added explicit `<label>` elements for County and City dropdowns in `GeographicFilter.tsx` with matching `id` on `SelectTrigger`
- Both mobile overlays (`FilterOverlay`, `InfoOverlay`) now use `aria-labelledby` pointing to heading `id`, close on Escape, move focus to close button on open, and restore focus to the trigger button on close
- Fixed copy-report-number button in `CrashPopup.tsx` — replaced mouse-only `title` with dynamic `aria-label`; both icon variants marked `aria-hidden`

Closes #178 